### PR TITLE
fix: make warn_admins aprs friendly

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -146,6 +146,16 @@ class APRSBackend(ErrBot):
         log.debug("Recieved msg %s", msg)
         super().callback_message(msg)
 
+    def warn_admins(self, warning: str) -> None:
+        """
+        Send a warning to the administrators of the bot.
+        For APRS this is too spammy over the airwaves, only log admin warnings to
+        the bots log at a warning level
+
+        :param warning: The markdown-formatted text of the message to send.
+        """
+        log.warning(warning)
+
     async def retry_worker(self) -> None:
         """Processes self._waiting_ack for messages we've sent that have not been acked
 


### PR DESCRIPTION
warn_admins can be very spammy. I had a plugin fail to load and it tried to send me 30 APRS messages with log spam.

This fixes that issue by capturing the admin warnings in the errbot log and not sending it as a message