### PR TITLE
fix: acks, login, filters, and APRS_BOT_CALLSIGN

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -2,8 +2,22 @@
 
 These options can be set in your errbot config.py to configure the APRS backend.
 
-* APRS_FROM_CALLSIGN - default is your bot identity callsign, but you can set to reply as a different callsign
-* APRS_LISTENED_CALLSIGNS - default (), set of callsigns to listen to
+## BOT_IDENTITY
+
+```
+BOT_ADMINS = (
+    "YOURCALL-SSID",
+)
+
+BOT_IDENTITY = {
+    "callsign": "YOURCALL-SSID",
+    "password": "APRSIS PASSWORD"
+}
+```
+
+## Other Config
+
+* APRS_BOT_CALLSIGN - default "", If set, the bot will listen on and reply from a differnent callsign than the one you signed in with. Good for setting a bot with a short callsign to run as a service (i.e. ANSRVR, REPEAT, etc)
 * APRS_HELP_TEXT - default "APRSBot,Errbot & err-aprs-backend", set this to your text. Probably a good idea to set it to website for complex help text due to message character limits
 * APRS_MAX_DROPPED_PACKETS - default "25", how many packets we can drop before the bot backend will restart
 * APRS_MAX_CACHED_PACKETS - default "2048", how many packets to hold in the cache to dedupe.

--- a/aprs_backend/exceptions/__init__.py
+++ b/aprs_backend/exceptions/__init__.py
@@ -2,6 +2,7 @@ from aprs_backend.exceptions.processor import ProcessorError
 from aprs_backend.exceptions.client.aprsis import (
     APRSISClientError,
     APRSISConnnectError,
+    APRSISLoginError,
     APRSISDeadConnectionError,
     APRSISPacketDecodeError,
     APRSISPacketError,
@@ -12,6 +13,7 @@ __all__ = [
     "ProcessorError",
     "APRSISClientError",
     "APRSISConnnectError",
+    "APRSISLoginError",
     "APRSISDeadConnectionError",
     "APRSISPacketDecodeError",
     "APRSISPacketError",

--- a/aprs_backend/exceptions/client/aprsis.py
+++ b/aprs_backend/exceptions/client/aprsis.py
@@ -9,6 +9,10 @@ class APRSISConnnectError(APRSISClientError):
     pass
 
 
+class APRSISLoginError(APRSISConnnectError):
+    pass
+
+
 class APRSISPacketError(APRSISClientError):
     pass
 

--- a/aprs_backend/packets/parser.py
+++ b/aprs_backend/packets/parser.py
@@ -250,4 +250,7 @@ def get_packet_type(packet: dict) -> str:
 
 @lru_cache(maxsize=128)
 def hash_packet(packet: AckPacket | MessagePacket | RejectPacket) -> str:
-    return sha256(f"{packet.to}-{packet.msgNo}-{packet.from_call}".encode()).hexdigest()
+    involved_stations = [packet.to, packet.addresse]
+    # alphabetize them for norming
+    involved_stations.sort()
+    return sha256((",".join(involved_stations) + f"-{packet.msgNo}").encode()).hexdigest()

--- a/docker/config.py
+++ b/docker/config.py
@@ -30,8 +30,7 @@ BOT_ADMINS = __callsign
 
 BOT_IDENTITY = {"callsign": __callsign, "password": __password}
 
-APRS_FROM_CALLSIGN = os.environ.get("APRS_FROM_CALLSIGN", __callsign)
-APRS_LISTENED_CALLSIGNS = tuple(os.environ.get("APRS_LISTENED_CALLSIGNS", "").strip(",").split(","))
+APRS_BOT_CALLSIGN = os.environ.get("APRS_BOT_CALLSIGN", __callsign)
 APRS_HELP_TEXT = os.environ.get("APRS_HELP_TEXT", "APRSBot,Errbot & err-aprs-backend")
 APRS_MAX_DROPPED_PACKETS = os.environ.get("APRS_MAX_DROPPED_PACKETS", "25")
 APRS_MAX_CACHED_PACKETS = os.environ.get("APRS_MAX_CACHED_PACKETS", "2048")


### PR DESCRIPTION
This fixes several bugs:
 * message acks were not properly removing messages from the _waiting_ack expiring dict, so messages were being retried that had been ackd. This was due to an incorrect hashing algorithim that did not correctly identify packets.
 * login method now checks for proper login and sends app versions and filters properly.

This also removes the APRS_LISTENING_CALLSIGNS that just did not work at all. There is no mechanism in Errbot of forwarding on a "reply-as" user for a message, so when a message for an additional callsign came in, all replies went out as just signed in callsigns.

This is replaced by APRS_BOT_CALLSIGN, which allows setting the bot and reply-from to a callsign separate from the one you're using to sign into APRSIS. This is useful for running a service bot, like ANSRVR or WXBOT. The bot will still listen on the signed in callsign as well, but if messaged there, will repy with the APRS_BOT_CALLSIGN callsign