### PR TITLE
feat: new core plugins

### DIFF
--- a/aprs_backend/APRSHealth.plug
+++ b/aprs_backend/APRSHealth.plug
@@ -1,0 +1,13 @@
+[Core]
+Name = APRSHealth
+Module = aprs_core_plugins
+Core = True
+
+[Documentation]
+Description = APRS Friendly Health Plugin
+
+[Python]
+Version = 3
+
+[Errbot]
+Min=6.2.0

--- a/aprs_backend/APRSHelp.plug
+++ b/aprs_backend/APRSHelp.plug
@@ -1,0 +1,13 @@
+[Core]
+Name = APRSHelp
+Module = aprs_core_plugins
+Core = True
+
+[Documentation]
+Description = APRS Friendly Help Plugin
+
+[Python]
+Version = 3
+
+[Errbot]
+Min=6.2.0

--- a/aprs_backend/APRSWebserver.plug
+++ b/aprs_backend/APRSWebserver.plug
@@ -1,0 +1,13 @@
+[Core]
+Name = APRSWebserver
+Module = aprs_core_plugins
+Core = True
+
+[Documentation]
+Description = APRS Friendly Web Plugin
+
+[Python]
+Version = 3
+
+[Errbot]
+Min=6.2.0

--- a/aprs_backend/aprs.plug
+++ b/aprs_backend/aprs.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = APRS
 Module = aprs
+Backend = True
 
 [Documentation]
 Description = Backend for APRS

--- a/aprs_backend/aprs.plug
+++ b/aprs_backend/aprs.plug
@@ -4,3 +4,9 @@ Module = aprs
 
 [Documentation]
 Description = Backend for APRS
+
+[Python]
+Version = 3
+
+[Errbot]
+Min=6.2.0

--- a/aprs_backend/aprs_core_plugins.py
+++ b/aprs_backend/aprs_core_plugins.py
@@ -1,0 +1,5 @@
+from aprs_backend.plugins import APRSHelp
+from aprs_backend.plugins import APRSWebserver
+from aprs_backend.plugins import APRSHealth
+
+__all__ = ["APRSHelp", "APRSWebserver", "APRSHealth"]

--- a/aprs_backend/plugins/__init__.py
+++ b/aprs_backend/plugins/__init__.py
@@ -1,0 +1,5 @@
+from aprs_backend.plugins.help import APRSHelp
+from aprs_backend.plugins.web import APRSWebserver
+from aprs_backend.plugins.health import APRSHealth
+
+__all__ = ["APRSHelp", "APRSWebserver", "APRSHealth"]

--- a/aprs_backend/plugins/health.py
+++ b/aprs_backend/plugins/health.py
@@ -1,0 +1,64 @@
+import gc
+from datetime import datetime
+
+from errbot import BotPlugin, webhook
+from errbot.utils import format_timedelta
+
+
+class APRSHealth(BotPlugin):
+    """Customized health plugin that shifts most of the outputs to webhooks and removes the botcmds"""
+
+    @webhook
+    def status(self, _):
+        """If I am alive I should be able to respond to this one"""
+        pm = self._bot.plugin_manager
+        all_blacklisted = pm.get_blacklisted_plugin()
+        all_loaded = pm.get_all_active_plugin_names()
+        all_attempted = sorted(pm.plugin_infos.keys())
+        plugins_statuses = []
+        for name in all_attempted:
+            if name in all_blacklisted:
+                if name in all_loaded:
+                    plugins_statuses.append(("BA", name))
+                else:
+                    plugins_statuses.append(("BD", name))
+            elif name in all_loaded:
+                plugins_statuses.append(("A", name))
+            elif (
+                pm.get_plugin_obj_by_name(name) is not None
+                and pm.get_plugin_obj_by_name(name).get_configuration_template() is not None
+                and pm.get_plugin_configuration(name) is None
+            ):
+                plugins_statuses.append(("C", name))
+            else:
+                plugins_statuses.append(("D", name))
+        loads = self.status_load("")
+        gc = self.status_gc("")
+
+        return {
+            "plugins_statuses": plugins_statuses,
+            "loads": loads["loads"],
+            "gc": gc["gc"],
+        }
+
+    @webhook
+    def status_load(self, _):
+        """shows the load status"""
+        try:
+            from posix import getloadavg
+
+            loads = getloadavg()
+        except Exception:
+            loads = None
+
+        return {"loads": loads}
+
+    @webhook
+    def status_gc(self, _):
+        """shows the garbage collection details"""
+        return {"gc": gc.get_count()}
+
+    @webhook
+    def uptime(self, _):
+        """Return the uptime of the bot"""
+        return {"up": format_timedelta(datetime.now() - self._bot.startup_time), "since": self._bot.startup_time}

--- a/aprs_backend/plugins/help.py
+++ b/aprs_backend/plugins/help.py
@@ -1,0 +1,23 @@
+from errbot import BotPlugin, botcmd
+
+
+class APRSHelp(BotPlugin):
+    """An alternative help plugin.
+
+    For now, it simply replies with preconfigured help text.
+
+    In the future, it would be great to use the internal webserver to serve
+    help text or generate it as a static file that could be served via
+    static site serving
+    """
+
+    def __init__(self, bot, name: str = "Help") -> None:
+        """
+        Calls super init and adds a few plugin variables of our own. This makes PEP8 happy
+        """
+        super().__init__(bot, name)
+        self.help_text = getattr(self._bot.bot_config, "APRS_HELP_TEXT")
+
+    @botcmd
+    def help(self, _, __):
+        return self.help_text

--- a/aprs_backend/plugins/web.py
+++ b/aprs_backend/plugins/web.py
@@ -1,0 +1,65 @@
+import logging
+from threading import Thread
+
+from webtest import TestApp
+from werkzeug.serving import ThreadedWSGIServer
+
+from errbot import BotPlugin, webhook
+from errbot.core_plugins import flask_app
+
+
+class APRSWebserver(BotPlugin):
+    def __init__(self, *args, **kwargs):
+        self.server = None
+        self.server_thread = None
+        self.ssl_context = None
+        self.test_app = TestApp(flask_app)
+        # TODO: Make this configurable in the APRS bot config, since there's no plugin config anymore
+        self.web_config = {"HOST": "0.0.0.0", "PORT": 3141}  # nosec
+        super().__init__(*args, **kwargs)
+
+    def activate(self):
+        if self.server_thread and self.server_thread.is_alive():
+            raise Exception("Invalid state, you should not have a webserver already running.")
+        self.server_thread = Thread(target=self.run_server, name="Webserver Thread")
+        self.server_thread.start()
+        self.log.debug("Webserver started.")
+
+        super().activate()
+
+    def deactivate(self):
+        if self.server is not None:
+            self.log.info("Shutting down the internal webserver.")
+            self.server.shutdown()
+            self.log.info("Waiting for the webserver thread to quit.")
+            self.server_thread.join()
+            self.log.info("Webserver shut down correctly.")
+        super().deactivate()
+
+    def run_server(self):
+        host = self.web_config["HOST"]
+        port = self.web_config["PORT"]
+        self.log.info("Starting the webserver on %s:%i", host, port)
+        try:
+            self.server = ThreadedWSGIServer(
+                host,
+                port,
+                flask_app,
+            )
+            wsgi_log = logging.getLogger("werkzeug")
+            wsgi_log.setLevel(self.bot_config.BOT_LOG_LEVEL)
+            self.server.serve_forever()
+        except KeyboardInterrupt:
+            self.log.info("Keyboard interrupt, request a global shutdown.")
+            self.server.shutdown()
+        except Exception as exc:
+            self.log.exception("Exception with webserver: %s", exc)
+        self.log.debug("Webserver stopped")
+
+    @webhook
+    def echo(self, incoming_request):
+        """
+        A simple test webhook
+        """
+        self.log.debug("Your incoming request is: %s", incoming_request)
+        return str(incoming_request)

--- a/aprs_backend/utils/plugins.py
+++ b/aprs_backend/utils/plugins.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from typing import Any
+from errbot.plugin_info import PluginInfo
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def _load_plugins_generic(
+    self,
+    path: Path,
+    extension: str,
+    base_module_name,
+    baseclass: type,
+    dest_dict: dict[str, Any],
+    dest_info_dict: dict[str, Any],
+    feedback: dict[Path, str],
+):
+    """Modified to remove the check for only a single plugin in a path"""
+    self._install_potential_package_dependencies(path, feedback)
+    plugfiles = path.glob("**/*." + extension)
+    for plugfile in plugfiles:
+        try:
+            plugin_info = PluginInfo.load(plugfile)
+            name = plugin_info.name
+            if name in dest_info_dict:
+                log.warning("Plugin %s already loaded.", name)
+                continue
+
+            # save the plugin_info for ref.
+            dest_info_dict[name] = plugin_info
+
+            # Skip the core plugins not listed in CORE_PLUGINS if CORE_PLUGINS is defined.
+            if self.core_plugins and plugin_info.core and (plugin_info.name not in self.core_plugins):
+                log.debug(
+                    "%s plugin will not be loaded because it's not listed in CORE_PLUGINS",
+                    name,
+                )
+                continue
+
+            plugin_classes = plugin_info.load_plugin_classes(base_module_name, baseclass)
+            if not plugin_classes:
+                feedback[path] = f"Did not find any plugin in {path}."
+                continue
+
+            # instantiate the plugin object.
+            if len(plugin_classes) > 1:
+                # multiple plugins in one module, need to find it by name
+                if (
+                    this_plugin_class := {
+                        plugin_class_tuple[0]: plugin_class_tuple[1] for plugin_class_tuple in plugin_classes
+                    }.get(name, None)
+                ) is None:
+                    feedback[path] = f"Unable to find plugin {name} in {path}"
+                    continue
+            else:
+                this_plugin_class = plugin_classes[0][1]
+            dest_dict[name] = self._plugin_instance_callback(name, this_plugin_class)
+
+        except Exception as exc:
+            feedback[path] = str(exc)
+
+
+def activate_non_started_plugins(self) -> str:
+    """
+    Activates all plugins that are not activated, respecting its dependencies.
+
+    Modified to fix https://github.com/errbotio/errbot/issues/1599
+    Can be removed after that bug is fixed
+
+    :return: Empty string if no problem occurred or a string explaining what went wrong.
+    """
+    log.info("Activate bot plugins...")
+    errors = ""
+    for name in self.get_plugins_activation_order():
+        plugin = self.plugins.get(name)
+        try:
+            if self.is_plugin_blacklisted(name):
+                errors += f"Notice: {plugin.name} is blacklisted"
+                continue
+            if plugin is not None and not plugin.is_activated:
+                log.info("Activate plugin: %s.", name)
+                self.activate_plugin(name)
+        except Exception as exc:
+            log.exception("Error loading %s - %s", name, exc)
+            errors += f"Error: {name} failed to activate: {exc}.\n"
+
+    log.debug("Activate flow plugins ...")
+    for name, flow in self.flows.items():
+        try:
+            if not flow.is_activated:
+                log.info("Activate flow: %s", name)
+                self.activate_flow(name)
+        except Exception as e:
+            log.exception(f"Error loading flow {name}.")
+            errors += f"Error: flow {name} failed to start: {e}.\n"
+    return errors

--- a/aprs_backend/utils/plugins.py
+++ b/aprs_backend/utils/plugins.py
@@ -1,9 +1,124 @@
 from pathlib import Path
 from typing import Any
-from errbot.plugin_info import PluginInfo
+from configparser import Error as ConfigParserError
 import logging
+from errbot.utils import version2tuple
+from configparser import ConfigParser
+from dataclasses import dataclass
+from importlib._bootstrap import module_from_spec
+import inspect
+from importlib._bootstrap_external import spec_from_file_location
+import sys
 
 log = logging.getLogger(__name__)
+
+VersionType = tuple[int, int, int]
+
+
+@dataclass
+class APRSPluginInfo:
+    """This is a replacement of errbot.plugin_info.PluginInfo
+
+    it adds the backend value to the Core section of the config
+    to indicate a plugin is a backend plugin.
+
+    This allows backend plugins to be skipped when loading plugins
+    and precents errors spam as the APRS backend plugin tries to double
+    load itself
+    """
+
+    name: str
+    module: str
+    doc: str
+    core: bool
+    python_version: VersionType
+    errbot_minversion: VersionType
+    errbot_maxversion: VersionType
+    dependencies: list[str]
+    backend: bool = False
+    location: Path | None = None
+
+    @staticmethod
+    def load(plugfile_path: Path) -> "APRSPluginInfo":
+        with plugfile_path.open(encoding="utf-8") as plugfile:
+            return APRSPluginInfo.load_file(plugfile, plugfile_path)
+
+    @staticmethod
+    def load_file(plugfile, location: Path) -> "APRSPluginInfo":
+        cp = ConfigParser()
+        cp.read_file(plugfile)
+        pi = APRSPluginInfo.parse(cp)
+        pi.location = location
+        return pi
+
+    @staticmethod
+    def parse(config: ConfigParser) -> "APRSPluginInfo":
+        """
+        Throws ConfigParserError with a meaningful message if the ConfigParser doesn't contain the minimal
+         information required.
+        """
+        name = config.get("Core", "Name")
+        module = config.get("Core", "Module")
+        core = config.get("Core", "Core", fallback="false").lower() == "true"
+        doc = config.get("Documentation", "Description", fallback=None)
+        # this is added for filtering out APRS Backend during plugin loading later
+        backend = config.get("Core", "Backend", fallback="false").lower() == "true"
+
+        python_version = config.get("Python", "Version", fallback=None)
+        # Old format backward compatibility
+        if python_version:
+            if python_version in ("2+", "3"):
+                python_version = (3, 0, 0)
+            elif python_version == "2":
+                python_version = (2, 0, 0)
+            else:
+                try:
+                    python_version = tuple(version2tuple(python_version)[0:3])  # We can ignore the alpha/beta part.
+                except ValueError as ve:
+                    raise ConfigParserError(f"Invalid Python Version format: {python_version} ({ve})")
+
+        min_version = config.get("Errbot", "Min", fallback=None)
+        max_version = config.get("Errbot", "Max", fallback=None)
+        try:
+            if min_version:
+                min_version = version2tuple(min_version)
+        except ValueError as ve:
+            raise ConfigParserError(f"Invalid Errbot min version format: {min_version} ({ve})")
+
+        try:
+            if max_version:
+                max_version = version2tuple(max_version)
+        except ValueError as ve:
+            raise ConfigParserError(f"Invalid Errbot max version format: {max_version} ({ve})")
+        depends_on = config.get("Core", "DependsOn", fallback=None)
+        deps = [name.strip() for name in depends_on.split(",")] if depends_on else []
+
+        return APRSPluginInfo(
+            name=name,
+            module=module,
+            doc=doc,
+            core=core,
+            backend=backend,
+            python_version=python_version,
+            errbot_minversion=min_version,
+            errbot_maxversion=max_version,
+            dependencies=deps,
+        )
+
+    def load_plugin_classes(self, base_module_name: str, baseclass: type) -> list:
+        # load the module
+        module_name = base_module_name + "." + self.module
+        spec = spec_from_file_location(module_name, self.location.parent / (self.module + ".py"))
+        modu1e = module_from_spec(spec)
+        spec.loader.exec_module(modu1e)
+        sys.modules[module_name] = modu1e
+
+        # introspect the modules to find plugin classes
+        def is_plugin(member):
+            return inspect.isclass(member) and issubclass(member, baseclass) and member != baseclass
+
+        plugin_classes = inspect.getmembers(modu1e, is_plugin)
+        return plugin_classes
 
 
 def _load_plugins_generic(
@@ -16,12 +131,22 @@ def _load_plugins_generic(
     dest_info_dict: dict[str, Any],
     feedback: dict[Path, str],
 ):
-    """Modified to remove the check for only a single plugin in a path"""
+    """Modified for use with the APRS Backend
+
+    * Removes the check for only a single plugin in a module and
+      adds logic to be able to load a plugin class by name from
+      the module
+    * Adds logic to skip backend plugins found when searching for plugs
+    """
     self._install_potential_package_dependencies(path, feedback)
     plugfiles = path.glob("**/*." + extension)
     for plugfile in plugfiles:
         try:
-            plugin_info = PluginInfo.load(plugfile)
+            plugin_info = APRSPluginInfo.load(plugfile)
+            # filter out any backend plugs from here
+            if getattr(plugin_info, "backend", False):
+                log.debug("%s is a backend plugin, not loading", plugin_info.name)
+                continue
             name = plugin_info.name
             if name in dest_info_dict:
                 log.warning("Plugin %s already loaded.", name)

--- a/docker/config.py
+++ b/docker/config.py
@@ -61,11 +61,7 @@ SUPPRESS_CMD_NOT_FOUND = True
 
 # core plugins are not APRS optimized, only load ones that work
 # this causes some erros in the logs
-CORE_PLUGINS = (
-    "ACLs",
-    "CommandNotFoundFilter",
-    "VersionCheck" "Webserver",
-)
+CORE_PLUGINS = ("ACLs", "CommandNotFoundFilter", "VersionCheck", "APRSHelp", "APRSWebserver", "APRSHealth")
 
 for env_var, value in os.environ.items():
     if env_var.startswith("ERR_APRS_"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ httpx = "^0.27.0"
 [tool.poetry.plugins."errbot.backend_plugins"]
 aprs = "aprs_backend:APRSBackend"
 
+[tool.poetry.plugins."errbot.plugins"]
+help = "aprs_backend:APRSHelp"
+
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
 coverage = {extras = ["toml"], version = ">=6.5,<8.0"}


### PR DESCRIPTION
This adds new core plugins for Help, Webserver, and Health and supporting code to make it possible to load them.

I had to overload some of the Err backend methods and monkey patch some methods in the PluginManager to allow loading multiple plugins from a single module and to exclude backend .plug files from _load_plugins_generic. 

Eventually, I'd like to upstream these changes, and some of this code will no longer be needed. 