### PR TITLE
fix(aprs): snapshot waiting_ack items under single lock to prevent race in retry_worker

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -213,16 +213,9 @@ class APRSBackend(ErrBot):
         log.debug("retry_worker started")
         while True:
             async with self._waiting_ack_lock:
-                current_keys = self._waiting_ack.keys()
-            for key in current_keys:
-                async with self._waiting_ack_lock:
-                    this_packet = self._waiting_ack.get(key, None)
-
-                # packet will be none if this packet has expired or been ack'd or
-                # rejected in between us pulling keys and getting it
-                if this_packet is None:
-                    continue
-
+                current_items = list(self._waiting_ack.items())
+            for key, this_packet in current_items:
+                # snapshot taken under lock; no reacquire needed
                 # check max retries first, its cheaper than a timedelta
                 if this_packet.last_send_attempt > self._message_max_retry:
                     log.debug("Packet %s over max retries, dropping %s", key, this_packet.json)

--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -205,28 +205,43 @@ class APRSBackend(ErrBot):
         log.warning(warning)
 
     async def retry_worker(self) -> None:
-        """Processes self._waiting_ack for messages we've sent that have not been acked
+        """Processes self._waiting_ack for messages we've sent that have not been acked.
+
+        A snapshot of _waiting_ack is taken under a single lock hold at the top of each
+        cycle.  Every snapshot entry is re-validated for liveness against the live dict
+        immediately before it is acted upon, because await points inside the loop let
+        _process_ack_rej or ExpiringDict cleanup remove entries mid-cycle.  Concurrently
+        removed entries are skipped (not resent, not dropped).
 
         Will resend a message up to APRS_MESSAGE_MAX_RETRIES number of tries while waiting
-        at least APRS_MESSAGE_RETRY_WAIT seconds between retries
+        at least APRS_MESSAGE_RETRY_WAIT seconds between retries.
         """
         log.debug("retry_worker started")
         while True:
             async with self._waiting_ack_lock:
                 current_items = list(self._waiting_ack.items())
             for key, this_packet in current_items:
-                # snapshot taken under lock; no reacquire needed
+                # Re-validate liveness against the live dict: entries may have been
+                # removed concurrently by _process_ack_rej or ExpiringDict cleanup
+                # while earlier keys were being processed (await points yield control).
+                # Skip any entry that is no longer present so we never resend an
+                # already-ACKed message or drop an already-absent entry.
+                async with self._waiting_ack_lock:
+                    live_packet = self._waiting_ack.get(key)
+                if live_packet is None:
+                    continue
+
                 # check max retries first, its cheaper than a timedelta
-                if this_packet.last_send_attempt > self._message_max_retry:
-                    log.debug("Packet %s over max retries, dropping %s", key, this_packet.json)
+                if live_packet.last_send_attempt > self._message_max_retry:
+                    log.debug("Packet %s over max retries, dropping %s", key, live_packet.json)
                     await self.__drop_message_from_waiting(key)
                     continue
 
                 # if this packet has not been sent in self._message_retry_wait seconds, resend it
                 # because it hasn't been ack'd yet
-                if (datetime.now() - this_packet.last_send_time).total_seconds() > self._message_retry_wait:
-                    log.debug("Message %s needs to be re-sent %s", key, this_packet.json)
-                    self.send_message(APRSMessage.from_message_packet(this_packet))
+                if (datetime.now() - live_packet.last_send_time).total_seconds() > self._message_retry_wait:
+                    log.debug("Message %s needs to be re-sent %s", key, live_packet.json)
+                    self.send_message(APRSMessage.from_message_packet(live_packet))
                 # release the loop for a bit
                 await asyncio.sleep(0.001)
             # release the loop for a bit longer after we've gone through all keys

--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -220,7 +220,7 @@ class APRSBackend(ErrBot):
         while True:
             async with self._waiting_ack_lock:
                 current_items = list(self._waiting_ack.items())
-            for key, this_packet in current_items:
+            for key, _ in current_items:
                 # Re-validate liveness against the live dict: entries may have been
                 # removed concurrently by _process_ack_rej or ExpiringDict cleanup
                 # while earlier keys were being processed (await points yield control).

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -396,8 +396,7 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
         else:
             await real_sleep(delay)
 
-    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep_with_drop), \
-         patch("aprs_backend.aprs.log") as mock_log:
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep_with_drop), patch("aprs_backend.aprs.log") as mock_log:
         task = asyncio.create_task(backend.retry_worker())
         # Wait long enough for the cycle to complete
         await real_sleep(0.1)
@@ -409,8 +408,7 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
 
     # Entry 2 was removed mid-cycle, so it must NOT have been resent.
     sent_keys = [p.addresse + "-" + p.msgNo for p in sent_packets if p is not None]
-    assert "REMOTE-1-2" not in sent_keys, \
-        "send_message must NOT be called for an entry ACKed mid-cycle"
+    assert "REMOTE-1-2" not in sent_keys, "send_message must NOT be called for an entry ACKed mid-cycle"
 
     # No error-level log should be emitted for the expected concurrent removal
     mock_log.error.assert_not_called()

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -104,9 +104,11 @@ def _run_one_cycle(backend):
 
 
 @pytest.mark.asyncio
-async def test_retry_worker_single_lock_acquisition_per_cycle(backend):
-    """retry_worker must acquire _waiting_ack_lock only once per cycle
-    when snapshotting entries (O(1) not O(N))."""
+async def test_retry_worker_single_snapshot_lock_per_cycle(backend):
+    """retry_worker takes the snapshot under a single lock hold (O(1)),
+    then does a lightweight per-entry liveness check (one short lock hold
+    per entry).  With one entry present, we expect 2 acquisitions:
+    1 for the snapshot + 1 for the liveness check."""
 
     instrumented = InstrumentedLock()
     backend._waiting_ack_lock = instrumented
@@ -125,7 +127,8 @@ async def test_retry_worker_single_lock_acquisition_per_cycle(backend):
         except asyncio.CancelledError:
             pass
 
-    assert instrumented.acquire_count == 1
+    # 1 snapshot acquisition + 1 liveness check for the single entry
+    assert instrumented.acquire_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -338,3 +341,76 @@ async def test_retry_worker_checks_max_retries_before_timing(backend):
     assert drop_called, "Entry over max retries should be dropped"
     assert not send_called, "Entry over max retries should NOT be resent (max-retries check first)"
     assert "REMOTE-1-1" not in backend._waiting_ack
+
+
+# ---------------------------------------------------------------------------
+# Test: freshness guard — ACKed mid-cycle entry is skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
+    """When a snapshot entry is ACKed/REJed between snapshot time and the
+    resend branch, retry_worker must NOT call send_message for it and must
+    NOT emit an error-level log for its drop."""
+
+    # Seed two entries: one that will be ACKed mid-cycle (entry 1) and one
+    # that stays (entry 2).  Both are overdue so they would normally resend.
+    for i in (1, 2):
+        pkt = _make_packet(msgno=i, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200))
+        backend._waiting_ack[f"REMOTE-1-{i}"] = pkt
+
+    sent_packets = []
+
+    def track_send(msg):
+        # The packet is stored in the extras dict
+        sent_packets.append(msg.extras.get("packet"))
+
+    backend.send_message = MagicMock(side_effect=track_send)
+
+    original_drop = backend._APRSBackend__drop_message_from_waiting
+
+    async def tracked_drop(message_hash: str) -> None:
+        await original_drop(message_hash)
+
+    backend._APRSBackend__drop_message_from_waiting = tracked_drop
+
+    # Patch the per-entry sleep(0.001) so we can drop entry 2 between
+    # the processing of entry 1 and entry 2 in the snapshot iteration.
+    # Use a counter to know which iteration we're on.
+    sleep_call_count = 0
+    real_sleep = asyncio.sleep
+
+    async def patched_sleep_with_drop(delay):
+        nonlocal sleep_call_count
+        if delay == 0.001:
+            sleep_call_count += 1
+            # After the first entry has been processed (first sleep),
+            # drop the second entry from _waiting_ack to simulate
+            # a concurrent ACK arriving.
+            if sleep_call_count == 1:
+                await backend._APRSBackend__drop_message_from_waiting("REMOTE-1-2")
+        elif delay == 5:
+            # End of cycle — block until cancelled
+            await real_sleep(999999)
+        else:
+            await real_sleep(delay)
+
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep_with_drop), \
+         patch("aprs_backend.aprs.log") as mock_log:
+        task = asyncio.create_task(backend.retry_worker())
+        # Wait long enough for the cycle to complete
+        await real_sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Entry 2 was removed mid-cycle, so it must NOT have been resent.
+    sent_keys = [p.addresse + "-" + p.msgNo for p in sent_packets if p is not None]
+    assert "REMOTE-1-2" not in sent_keys, \
+        "send_message must NOT be called for an entry ACKed mid-cycle"
+
+    # No error-level log should be emitted for the expected concurrent removal
+    mock_log.error.assert_not_called()

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -255,15 +255,11 @@ async def test_retry_worker_resends_overdue_but_not_recent(backend):
     entry does not."""
 
     # Overdue packet (sent 200 seconds ago, wait is 90s)
-    overdue_pkt = _make_packet(
-        msgno=1, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200)
-    )
+    overdue_pkt = _make_packet(msgno=1, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200))
     backend._waiting_ack["REMOTE-1-1"] = overdue_pkt
 
     # Recent packet (sent 10 seconds ago, wait is 90s)
-    recent_pkt = _make_packet(
-        msgno=2, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=10)
-    )
+    recent_pkt = _make_packet(msgno=2, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=10))
     backend._waiting_ack["REMOTE-1-2"] = recent_pkt
 
     sent_messages = []
@@ -306,9 +302,7 @@ async def test_retry_worker_checks_max_retries_before_timing(backend):
     An entry over max retries should be dropped even if it is also overdue."""
 
     # Entry that is both over max retries AND overdue
-    pkt = _make_packet(
-        msgno=1, last_send_attempt=8, last_send_time=datetime.now() - timedelta(seconds=200)
-    )
+    pkt = _make_packet(msgno=1, last_send_attempt=8, last_send_time=datetime.now() - timedelta(seconds=200))
     backend._waiting_ack["REMOTE-1-1"] = pkt
 
     drop_called = False

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -32,7 +32,7 @@ class _BotConfig:
     APRS_CONNECT_TIMEOUT = "30.0"
     APRS_SEND_MAX_QUEUE = "2048"
     APRS_MAX_DROPPED_PACKETS = "25"
-    APRS_MAX_CACHED_PACKETS = "2048"
+    APRS_MAX_CACHED_PACETS = "2048"
     APRS_MESSAGE_MAX_RETRIES = "7"
     APRS_MESSAGE_RETRY_WAIT = "90"
     APRS_STRIP_NEWLINES = "true"
@@ -78,6 +78,26 @@ def _make_packet(msgno: int = 1, last_send_attempt: int = 0, last_send_time: dat
     return pkt
 
 
+def _run_one_cycle(backend):
+    """Run retry_worker() for exactly one cycle by patching the trailing sleep(5)
+    to set an event and then sleep forever.  The caller waits for the event,
+    cancels the task, and swallows CancelledError."""
+    event = asyncio.Event()
+
+    original_sleep = asyncio.sleep
+
+    async def patched_sleep(delay):
+        if delay == 5:
+            # End of one cycle — signal and block so the worker stays
+            # paused here until the caller cancels it.
+            event.set()
+            await original_sleep(999999)
+        else:
+            await original_sleep(delay)
+
+    return event, patched_sleep
+
+
 # ---------------------------------------------------------------------------
 # Test: retry_worker acquires lock O(1) per cycle
 # ---------------------------------------------------------------------------
@@ -94,24 +114,16 @@ async def test_retry_worker_single_lock_acquisition_per_cycle(backend):
     pkt = _make_packet(msgno=1, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200))
     backend._waiting_ack["REMOTE-1-1"] = pkt
 
-    # Run retry_worker for just enough time to complete one iteration over
-    # the snapshot, then cancel it. We patch the final sleep(5) so the test
-    # doesn't wait.
-    async def run_one_cycle():
-        # Manually execute one cycle: snapshot under lock, then iterate.
-        # This mirrors what retry_worker does in its loop body.
-        async with backend._waiting_ack_lock:
-            current_items = list(backend._waiting_ack.items())
-        # Iterate outside the lock (as retry_worker does)
-        for key, this_packet in current_items:
-            if this_packet.last_send_attempt > backend._message_max_retry:
-                await backend._APRSBackend__drop_message_from_waiting(key)
-                continue
-            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
-                backend.send_message(MagicMock())
-            await asyncio.sleep(0.001)
+    event, patched_sleep = _run_one_cycle(backend)
 
-    await run_one_cycle()
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep):
+        task = asyncio.create_task(backend.retry_worker())
+        await event.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     assert instrumented.acquire_count == 1
 
@@ -144,20 +156,18 @@ async def test_retry_worker_no_runtime_error_under_concurrent_drop(backend):
                 runtime_error_raised = True
             raise
 
-    async def one_retry_cycle():
-        """Execute one retry_worker cycle (mirrors the real loop body)."""
-        async with backend._waiting_ack_lock:
-            current_items = list(backend._waiting_ack.items())
-        for key, this_packet in current_items:
-            if this_packet.last_send_attempt > backend._message_max_retry:
-                await backend._APRSBackend__drop_message_from_waiting(key)
-                continue
-            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
-                backend.send_message(MagicMock())
-            await asyncio.sleep(0.001)
+    event, patched_sleep = _run_one_cycle(backend)
 
-    # Run both concurrently
-    await asyncio.gather(one_retry_cycle(), concurrent_drops())
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep):
+        retry_task = asyncio.create_task(backend.retry_worker())
+        drop_task = asyncio.create_task(concurrent_drops())
+        await event.wait()
+        retry_task.cancel()
+        try:
+            await retry_task
+        except asyncio.CancelledError:
+            pass
+        await drop_task
 
     assert not runtime_error_raised
 
@@ -186,18 +196,16 @@ async def test_retry_worker_no_duplicate_processing(backend):
         pkt = _make_packet(msgno=i, last_send_attempt=8, last_send_time=datetime.now() - timedelta(seconds=200))
         backend._waiting_ack[f"REMOTE-1-{i}"] = pkt
 
-    async def one_retry_cycle():
-        async with backend._waiting_ack_lock:
-            current_items = list(backend._waiting_ack.items())
-        for key, this_packet in current_items:
-            if this_packet.last_send_attempt > backend._message_max_retry:
-                await backend._APRSBackend__drop_message_from_waiting(key)
-                continue
-            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
-                backend.send_message(MagicMock())
-            await asyncio.sleep(0.001)
+    event, patched_sleep = _run_one_cycle(backend)
 
-    await one_retry_cycle()
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep):
+        task = asyncio.create_task(backend.retry_worker())
+        await event.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     # Each key should appear at most once
     assert len(processed_keys) == len(set(processed_keys))
@@ -226,18 +234,16 @@ async def test_retry_worker_drops_entry_over_max_retries(backend):
 
     backend._APRSBackend__drop_message_from_waiting = tracked_drop
 
-    async def one_retry_cycle():
-        async with backend._waiting_ack_lock:
-            current_items = list(backend._waiting_ack.items())
-        for key, this_packet in current_items:
-            if this_packet.last_send_attempt > backend._message_max_retry:
-                await backend._APRSBackend__drop_message_from_waiting(key)
-                continue
-            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
-                backend.send_message(MagicMock())
-            await asyncio.sleep(0.001)
+    event, patched_sleep = _run_one_cycle(backend)
 
-    await one_retry_cycle()
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep):
+        task = asyncio.create_task(backend.retry_worker())
+        await event.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     assert "REMOTE-1-1" in drop_called_with
     assert "REMOTE-1-1" not in backend._waiting_ack
@@ -269,20 +275,16 @@ async def test_retry_worker_resends_overdue_but_not_recent(backend):
 
     backend.send_message = MagicMock(side_effect=track_send)
 
-    async def one_retry_cycle():
-        async with backend._waiting_ack_lock:
-            current_items = list(backend._waiting_ack.items())
-        for key, this_packet in current_items:
-            if this_packet.last_send_attempt > backend._message_max_retry:
-                await backend._APRSBackend__drop_message_from_waiting(key)
-                continue
-            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
-                from aprs_backend.message import APRSMessage
+    event, patched_sleep = _run_one_cycle(backend)
 
-                backend.send_message(APRSMessage.from_message_packet(this_packet))
-            await asyncio.sleep(0.001)
-
-    await one_retry_cycle()
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep):
+        task = asyncio.create_task(backend.retry_worker())
+        await event.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     # Only the overdue packet should trigger a send
     assert len(sent_messages) == 1
@@ -322,20 +324,16 @@ async def test_retry_worker_checks_max_retries_before_timing(backend):
 
     backend.send_message = MagicMock(side_effect=track_send)
 
-    async def one_retry_cycle():
-        async with backend._waiting_ack_lock:
-            current_items = list(backend._waiting_ack.items())
-        for key, this_packet in current_items:
-            if this_packet.last_send_attempt > backend._message_max_retry:
-                await backend._APRSBackend__drop_message_from_waiting(key)
-                continue
-            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
-                from aprs_backend.message import APRSMessage
+    event, patched_sleep = _run_one_cycle(backend)
 
-                backend.send_message(APRSMessage.from_message_packet(this_packet))
-            await asyncio.sleep(0.001)
-
-    await one_retry_cycle()
+    with patch("aprs_backend.aprs.asyncio.sleep", patched_sleep):
+        task = asyncio.create_task(backend.retry_worker())
+        await event.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     assert drop_called, "Entry over max retries should be dropped"
     assert not send_called, "Entry over max retries should NOT be resent (max-retries check first)"

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -1,0 +1,348 @@
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aprs_backend.aprs import APRSBackend
+from aprs_backend.packets import MessagePacket
+
+
+class InstrumentedLock:
+    """Wrapper around asyncio.Lock that counts acquisitions."""
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self.acquire_count = 0
+
+    async def __aenter__(self):
+        self.acquire_count += 1
+        await self._lock.__aenter__()
+        return self
+
+    async def __aexit__(self, *args):
+        await self._lock.__aexit__(*args)
+
+
+class _BotConfig:
+    """Minimal bot config for constructing APRSBackend."""
+
+    BOT_IDENTITY = {"callsign": "TEST-1", "password": "1234"}
+    APRS_BOT_CALLSIGN = "TEST-1"
+    APRS_CONNECT_TIMEOUT = "30.0"
+    APRS_SEND_MAX_QUEUE = "2048"
+    APRS_MAX_DROPPED_PACKETS = "25"
+    APRS_MAX_CACHED_PACKETS = "2048"
+    APRS_MESSAGE_MAX_RETRIES = "7"
+    APRS_MESSAGE_RETRY_WAIT = "90"
+    APRS_STRIP_NEWLINES = "true"
+    APRS_LANGUAGE_FILTER = "false"
+    APRS_MAX_AGE_CACHED_PACETS_SECONDS = "3600"
+    APRS_REGISTRY_ENABLED = "false"
+    APRS_BEACON_ENABLE = "false"
+    # ErrBot base class requirements
+    BOT_PREFIX = "!"
+    BOT_ASYNC = False
+    BOT_ALT_PREFIXES = ()
+    BOT_ALT_PREFIX_CASEINSENSITIVE = False
+    MESSAGE_SIZE_LIMIT = None
+
+
+@pytest.fixture
+def bot_config():
+    return _BotConfig()
+
+
+@pytest.fixture
+def backend(bot_config):
+    """Create an APRSBackend instance with mocked _client."""
+    with patch("aprs_backend.aprs.APRSISClient"):
+        backend = APRSBackend(bot_config)
+    backend._client = AsyncMock()
+    # Mock send_message to avoid needing a live plugin_manager
+    backend.send_message = MagicMock()
+    return backend
+
+
+def _make_packet(msgno: int = 1, last_send_attempt: int = 0, last_send_time: datetime | None = None):
+    """Helper to create a MessagePacket for _waiting_ack."""
+    pkt = MessagePacket(
+        from_call="TEST-1",
+        to_call="REMOTE-1",
+        addresse="REMOTE-1",
+        message_text="hello",
+        msgNo=str(msgno),
+        last_send_attempt=last_send_attempt,
+    )
+    pkt.last_send_time = last_send_time or datetime.now()
+    return pkt
+
+
+# ---------------------------------------------------------------------------
+# Test: retry_worker acquires lock O(1) per cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_single_lock_acquisition_per_cycle(backend):
+    """retry_worker must acquire _waiting_ack_lock only once per cycle
+    when snapshotting entries (O(1) not O(N))."""
+
+    instrumented = InstrumentedLock()
+    backend._waiting_ack_lock = instrumented
+
+    pkt = _make_packet(msgno=1, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200))
+    backend._waiting_ack["REMOTE-1-1"] = pkt
+
+    # Run retry_worker for just enough time to complete one iteration over
+    # the snapshot, then cancel it. We patch the final sleep(5) so the test
+    # doesn't wait.
+    async def run_one_cycle():
+        # Manually execute one cycle: snapshot under lock, then iterate.
+        # This mirrors what retry_worker does in its loop body.
+        async with backend._waiting_ack_lock:
+            current_items = list(backend._waiting_ack.items())
+        # Iterate outside the lock (as retry_worker does)
+        for key, this_packet in current_items:
+            if this_packet.last_send_attempt > backend._message_max_retry:
+                await backend._APRSBackend__drop_message_from_waiting(key)
+                continue
+            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
+                backend.send_message(MagicMock())
+            await asyncio.sleep(0.001)
+
+    await run_one_cycle()
+
+    assert instrumented.acquire_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: concurrent ACK/REJ processing — no RuntimeError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_no_runtime_error_under_concurrent_drop(backend):
+    """Concurrent __drop_message_from_waiting while retry_worker iterates
+    must not raise RuntimeError: dictionary changed size during iteration."""
+
+    # Seed _waiting_ack with several entries
+    for i in range(1, 6):
+        pkt = _make_packet(msgno=i, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200))
+        backend._waiting_ack[f"REMOTE-1-{i}"] = pkt
+
+    runtime_error_raised = False
+
+    async def concurrent_drops():
+        nonlocal runtime_error_raised
+        try:
+            for i in range(1, 6):
+                await asyncio.sleep(0.001)
+                await backend._APRSBackend__drop_message_from_waiting(f"REMOTE-1-{i}")
+        except RuntimeError as exc:
+            if "dictionary changed size during iteration" in str(exc):
+                runtime_error_raised = True
+            raise
+
+    async def one_retry_cycle():
+        """Execute one retry_worker cycle (mirrors the real loop body)."""
+        async with backend._waiting_ack_lock:
+            current_items = list(backend._waiting_ack.items())
+        for key, this_packet in current_items:
+            if this_packet.last_send_attempt > backend._message_max_retry:
+                await backend._APRSBackend__drop_message_from_waiting(key)
+                continue
+            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
+                backend.send_message(MagicMock())
+            await asyncio.sleep(0.001)
+
+    # Run both concurrently
+    await asyncio.gather(one_retry_cycle(), concurrent_drops())
+
+    assert not runtime_error_raised
+
+
+# ---------------------------------------------------------------------------
+# Test: no entry processed more than once during concurrent iteration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_no_duplicate_processing(backend):
+    """Each entry in the snapshot must be processed at most once per cycle."""
+
+    processed_keys = []
+
+    original_drop = backend._APRSBackend__drop_message_from_waiting
+
+    async def tracked_drop(message_hash: str) -> None:
+        processed_keys.append(message_hash)
+        await original_drop(message_hash)
+
+    backend._APRSBackend__drop_message_from_waiting = tracked_drop
+
+    # Seed entries that exceed max retries so they get dropped
+    for i in range(1, 6):
+        pkt = _make_packet(msgno=i, last_send_attempt=8, last_send_time=datetime.now() - timedelta(seconds=200))
+        backend._waiting_ack[f"REMOTE-1-{i}"] = pkt
+
+    async def one_retry_cycle():
+        async with backend._waiting_ack_lock:
+            current_items = list(backend._waiting_ack.items())
+        for key, this_packet in current_items:
+            if this_packet.last_send_attempt > backend._message_max_retry:
+                await backend._APRSBackend__drop_message_from_waiting(key)
+                continue
+            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
+                backend.send_message(MagicMock())
+            await asyncio.sleep(0.001)
+
+    await one_retry_cycle()
+
+    # Each key should appear at most once
+    assert len(processed_keys) == len(set(processed_keys))
+
+
+# ---------------------------------------------------------------------------
+# Test: max-retry drop path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_drops_entry_over_max_retries(backend):
+    """An entry whose last_send_attempt > _message_max_retry is dropped
+    via __drop_message_from_waiting and removed from _waiting_ack."""
+
+    pkt = _make_packet(msgno=1, last_send_attempt=8, last_send_time=datetime.now())
+    backend._waiting_ack["REMOTE-1-1"] = pkt
+
+    # Patch __drop_message_from_waiting to track calls
+    drop_called_with = []
+
+    async def tracked_drop(message_hash: str) -> None:
+        drop_called_with.append(message_hash)
+        async with backend._waiting_ack_lock:
+            backend._waiting_ack.pop(message_hash, None)
+
+    backend._APRSBackend__drop_message_from_waiting = tracked_drop
+
+    async def one_retry_cycle():
+        async with backend._waiting_ack_lock:
+            current_items = list(backend._waiting_ack.items())
+        for key, this_packet in current_items:
+            if this_packet.last_send_attempt > backend._message_max_retry:
+                await backend._APRSBackend__drop_message_from_waiting(key)
+                continue
+            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
+                backend.send_message(MagicMock())
+            await asyncio.sleep(0.001)
+
+    await one_retry_cycle()
+
+    assert "REMOTE-1-1" in drop_called_with
+    assert "REMOTE-1-1" not in backend._waiting_ack
+
+
+# ---------------------------------------------------------------------------
+# Test: resend-timing path — overdue triggers send, recent does not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_resends_overdue_but_not_recent(backend):
+    """An entry whose elapsed time since last_send_time exceeds
+    _message_retry_wait triggers send_message, while a recently-sent
+    entry does not."""
+
+    # Overdue packet (sent 200 seconds ago, wait is 90s)
+    overdue_pkt = _make_packet(
+        msgno=1, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=200)
+    )
+    backend._waiting_ack["REMOTE-1-1"] = overdue_pkt
+
+    # Recent packet (sent 10 seconds ago, wait is 90s)
+    recent_pkt = _make_packet(
+        msgno=2, last_send_attempt=1, last_send_time=datetime.now() - timedelta(seconds=10)
+    )
+    backend._waiting_ack["REMOTE-1-2"] = recent_pkt
+
+    sent_messages = []
+
+    def track_send(msg):
+        sent_messages.append(msg)
+
+    backend.send_message = MagicMock(side_effect=track_send)
+
+    async def one_retry_cycle():
+        async with backend._waiting_ack_lock:
+            current_items = list(backend._waiting_ack.items())
+        for key, this_packet in current_items:
+            if this_packet.last_send_attempt > backend._message_max_retry:
+                await backend._APRSBackend__drop_message_from_waiting(key)
+                continue
+            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
+                from aprs_backend.message import APRSMessage
+
+                backend.send_message(APRSMessage.from_message_packet(this_packet))
+            await asyncio.sleep(0.001)
+
+    await one_retry_cycle()
+
+    # Only the overdue packet should trigger a send
+    assert len(sent_messages) == 1
+    # The recent packet should NOT have triggered a send
+    # (it's still in _waiting_ack since it wasn't over max retries)
+    assert "REMOTE-1-2" in backend._waiting_ack
+
+
+# ---------------------------------------------------------------------------
+# Test: max-retries check ordering — checked before resend-timing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_worker_checks_max_retries_before_timing(backend):
+    """Max-retries check must be evaluated before resend-timing check.
+    An entry over max retries should be dropped even if it is also overdue."""
+
+    # Entry that is both over max retries AND overdue
+    pkt = _make_packet(
+        msgno=1, last_send_attempt=8, last_send_time=datetime.now() - timedelta(seconds=200)
+    )
+    backend._waiting_ack["REMOTE-1-1"] = pkt
+
+    drop_called = False
+    send_called = False
+
+    async def tracked_drop(message_hash: str) -> None:
+        nonlocal drop_called
+        drop_called = True
+        async with backend._waiting_ack_lock:
+            backend._waiting_ack.pop(message_hash, None)
+
+    backend._APRSBackend__drop_message_from_waiting = tracked_drop
+
+    def track_send(msg):
+        nonlocal send_called
+        send_called = True
+
+    backend.send_message = MagicMock(side_effect=track_send)
+
+    async def one_retry_cycle():
+        async with backend._waiting_ack_lock:
+            current_items = list(backend._waiting_ack.items())
+        for key, this_packet in current_items:
+            if this_packet.last_send_attempt > backend._message_max_retry:
+                await backend._APRSBackend__drop_message_from_waiting(key)
+                continue
+            if (datetime.now() - this_packet.last_send_time).total_seconds() > backend._message_retry_wait:
+                from aprs_backend.message import APRSMessage
+
+                backend.send_message(APRSMessage.from_message_packet(this_packet))
+            await asyncio.sleep(0.001)
+
+    await one_retry_cycle()
+
+    assert drop_called, "Entry over max retries should be dropped"
+    assert not send_called, "Entry over max retries should NOT be resent (max-retries check first)"
+    assert "REMOTE-1-1" not in backend._waiting_ack


### PR DESCRIPTION
## Summary

Delivers parent issue #435: fix(aprs): snapshot waiting_ack items under single lock to prevent race in retry_worker

### Child issues integrated

- Closes #493 — Decide and enforce freshness contract for retry_worker snapshot iteration
- Closes #492 — Add test coverage for retry_worker and the _waiting_ack concurrency path

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #435 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`