### PR TITLE
fix(counter): move overflow check inside lock in MessageCounter.get_value_sync to prevent race condition

### DIFF
--- a/aprs_backend/utils/counter.py
+++ b/aprs_backend/utils/counter.py
@@ -8,22 +8,12 @@ class MessageCounter:
         self._value = initial_value
         self._max = max_message_count
 
-    async def increment(self):
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._increment)
-
     async def get_value(self, increment: bool = True) -> int:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._get_value, increment)
 
     def get_value_sync(self, increment: bool = True) -> int:
         return self._get_value(increment)
-
-    def _increment(self) -> None:
-        with self._lock:
-            self._value += 1
-            if self._value > self._max:
-                self._value = 1
 
     def _get_value(self, increment: bool = True) -> int:
         with self._lock:

--- a/aprs_backend/utils/counter.py
+++ b/aprs_backend/utils/counter.py
@@ -1,34 +1,34 @@
 import asyncio
-from threading import RLock
+from threading import Lock
 
 
 class MessageCounter:
     def __init__(self, initial_value: int = 1, max_message_count: int = 999):
-        self._lock = asyncio.Lock()
-        self._sync_lock = RLock()
+        self._lock = Lock()
         self._value = initial_value
         self._max = max_message_count
 
     async def increment(self):
-        async with self._lock:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._increment)
+
+    async def get_value(self, increment: bool = True) -> int:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._get_value, increment)
+
+    def get_value_sync(self, increment: bool = True) -> int:
+        return self._get_value(increment)
+
+    def _increment(self) -> None:
+        with self._lock:
             self._value += 1
             if self._value > self._max:
                 self._value = 1
 
-    async def get_value(self, increment: bool = True) -> int:
-        async with self._lock:
+    def _get_value(self, increment: bool = True) -> int:
+        with self._lock:
             if increment:
                 self._value += 1
                 if self._value > self._max:
                     self._value = 1
-            this_val = self._value
-        return this_val
-
-    def get_value_sync(self, increment: bool = True) -> int:
-        with self._sync_lock:
-            if increment:
-                self._value += 1
-                if self._value > self._max:
-                    self._value = 1
-            this_val = self._value
-        return this_val
+            return self._value

--- a/aprs_backend/utils/counter.py
+++ b/aprs_backend/utils/counter.py
@@ -16,18 +16,19 @@ class MessageCounter:
                 self._value = 1
 
     async def get_value(self, increment: bool = True) -> int:
-        if increment:
-            await self.increment()
         async with self._lock:
+            if increment:
+                self._value += 1
+                if self._value > self._max:
+                    self._value = 1
             this_val = self._value
         return this_val
 
     def get_value_sync(self, increment: bool = True) -> int:
-        if increment:
-            with self._sync_lock:
-                self._value += 1
-            if self._value > self._max:
-                self._value = 1
         with self._sync_lock:
+            if increment:
+                self._value += 1
+                if self._value > self._max:
+                    self._value = 1
             this_val = self._value
         return this_val

--- a/tests/utils/test_counter.py
+++ b/tests/utils/test_counter.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 
 import pytest
 
@@ -91,3 +92,47 @@ async def test_concurrency_stress():
         if 2 <= v <= remainder + 1:
             expected += 1
         assert count == expected, f"Value {v} appeared {count} times, expected {expected}"
+
+
+@pytest.mark.asyncio
+async def test_cross_path_stress():
+    """Run sync get_value_sync() (dispatched via threads) and async get_value()
+    concurrently and assert all returned values stay within 1.._max and the
+    counter never exceeds _max."""
+    max_val = 999
+    counter = MessageCounter(initial_value=1, max_message_count=max_val)
+    num_per_path = 2500
+    results: list[int] = []
+    results_lock = threading.Lock()
+    errors: list[str] = []
+
+    def sync_worker():
+        for _ in range(num_per_path):
+            v = counter.get_value_sync()
+            with results_lock:
+                results.append(v)
+                if v < 1 or v > max_val:
+                    errors.append(f"Value {v} out of range 1-{max_val}")
+
+    async def async_worker():
+        for _ in range(num_per_path):
+            v = await counter.get_value()
+            with results_lock:
+                results.append(v)
+                if v < 1 or v > max_val:
+                    errors.append(f"Value {v} out of range 1-{max_val}")
+
+    # Launch sync workers via threads
+    sync_threads = [threading.Thread(target=sync_worker) for _ in range(4)]
+    for t in sync_threads:
+        t.start()
+
+    # Launch async workers concurrently on the event loop
+    await asyncio.gather(*(async_worker() for _ in range(4)))
+
+    # Wait for sync threads to finish
+    for t in sync_threads:
+        t.join()
+
+    assert not errors, f"Range violations detected: {errors[:10]}"
+    assert len(results) == num_per_path * 8, f"Expected {num_per_path * 8} results, got {len(results)}"

--- a/tests/utils/test_counter.py
+++ b/tests/utils/test_counter.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+
+from aprs_backend.utils.counter import MessageCounter
+
+
+@pytest.mark.asyncio
+async def test_basic_increment():
+    counter = MessageCounter(initial_value=1, max_message_count=999)
+    val = await counter.get_value()
+    assert val == 2
+
+
+@pytest.mark.asyncio
+async def test_basic_increment_sync():
+    counter = MessageCounter(initial_value=1, max_message_count=999)
+    val = counter.get_value_sync()
+    assert val == 2
+
+
+@pytest.mark.asyncio
+async def test_overflow_wrap():
+    counter = MessageCounter(initial_value=998, max_message_count=999)
+    val1 = await counter.get_value()
+    assert val1 == 999
+    val2 = await counter.get_value()
+    assert val2 == 1
+
+
+@pytest.mark.asyncio
+async def test_overflow_wrap_sync():
+    counter = MessageCounter(initial_value=998, max_message_count=999)
+    val1 = counter.get_value_sync()
+    assert val1 == 999
+    val2 = counter.get_value_sync()
+    assert val2 == 1
+
+
+@pytest.mark.asyncio
+async def test_increment_false_no_bump():
+    counter = MessageCounter(initial_value=5, max_message_count=999)
+    val1 = await counter.get_value(increment=False)
+    val2 = await counter.get_value(increment=False)
+    assert val1 == 5
+    assert val2 == 5
+
+
+@pytest.mark.asyncio
+async def test_increment_false_no_bump_sync():
+    counter = MessageCounter(initial_value=5, max_message_count=999)
+    val1 = counter.get_value_sync(increment=False)
+    val2 = counter.get_value_sync(increment=False)
+    assert val1 == 5
+    assert val2 == 5
+
+
+@pytest.mark.asyncio
+async def test_concurrency_stress():
+    """Drive many concurrent get_value() calls and assert every returned value
+    is within 1.._max with no unexpected duplicates or skips beyond wrap."""
+    max_val = 999
+    counter = MessageCounter(initial_value=1, max_message_count=max_val)
+    num_calls = 5000
+    results = []
+
+    async def call_get_value():
+        v = await counter.get_value()
+        results.append(v)
+
+    await asyncio.gather(*(call_get_value() for _ in range(num_calls)))
+
+    # Every value must be within range
+    for v in results:
+        assert 1 <= v <= max_val, f"Value {v} out of range 1-{max_val}"
+
+    # With num_calls increments starting from initial_value=1, the counter
+    # cycles through 1..max_val repeatedly. Collect the sequence in order of
+    # expected values: the first call returns 2, second returns 3, ...,
+    # wrapping back. We check that the sorted results match the expected
+    # distribution of values across the cycles.
+    expected_count = num_calls // max_val
+    remainder = num_calls % max_val
+    for v in range(1, max_val + 1):
+        count = results.count(v)
+        # Each value appears expected_count times, plus one extra for the
+        # first `remainder` values in the wrap sequence.
+        expected = expected_count
+        # Values 2 through (remainder+1) get an extra hit (since initial=1,
+        # first increment yields 2).
+        if 2 <= v <= remainder + 1:
+            expected += 1
+        assert count == expected, (
+            f"Value {v} appeared {count} times, expected {expected}"
+        )

--- a/tests/utils/test_counter.py
+++ b/tests/utils/test_counter.py
@@ -90,6 +90,4 @@ async def test_concurrency_stress():
         # first increment yields 2).
         if 2 <= v <= remainder + 1:
             expected += 1
-        assert count == expected, (
-            f"Value {v} appeared {count} times, expected {expected}"
-        )
+        assert count == expected, f"Value {v} appeared {count} times, expected {expected}"


### PR DESCRIPTION
## Summary

Delivers parent issue #437: fix(counter): move overflow check inside lock in MessageCounter.get_value_sync to prevent race condition

### Child issues integrated

- Closes #499 — Dedupe increment/overflow-wrap logic and resolve dead increment() path in MessageCounter
- Closes #498 — fix(counter): unify MessageCounter to a single lock strategy so sync and async paths mutually exclude
- Closes #497 — fix(counter): make increment + overflow guard + read atomic in MessageCounter (sync and async paths)

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #437 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`