### PR TITLE
fix(parser): extract hash_packet cache key to immutable primitive fields

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -455,7 +455,7 @@ class APRSBackend(ErrBot):
         log.debug(packet.raw_dict)
         # send an ack to this message
         await self._ack_message(packet)
-        this_packet_hash = hash_packet(packet)
+        this_packet_hash = hash_packet(packet.to, packet.addresse, packet.msgNo)
         async with self._packet_cache_lock:
             if self._packet_cache.get(this_packet_hash, None) is not None:
                 log.info("Duplicate packet %s. Skipping processing", packet.json)

--- a/aprs_backend/packets/parser.py
+++ b/aprs_backend/packets/parser.py
@@ -248,9 +248,7 @@ def get_packet_type(packet: dict) -> str:
     return packet_type
 
 
-@lru_cache(maxsize=128)
-def hash_packet(packet: AckPacket | MessagePacket | RejectPacket) -> str:
-    involved_stations = [packet.to, packet.addresse]
-    # alphabetize them for norming
-    involved_stations.sort()
-    return sha256((",".join(involved_stations) + f"-{packet.msgNo}").encode()).hexdigest()
+@lru_cache(maxsize=256)
+def hash_packet(to: str, addresse: str, msg_no: str) -> str:
+    stations = tuple(sorted((to, addresse)))
+    return sha256((",".join(stations) + f"-{msg_no}").encode()).hexdigest()

--- a/aprs_backend/packets/parser.py
+++ b/aprs_backend/packets/parser.py
@@ -249,6 +249,17 @@ def get_packet_type(packet: dict) -> str:
 
 
 @lru_cache(maxsize=256)
-def hash_packet(to: str, addresse: str, msg_no: str) -> str:
-    stations = tuple(sorted((to, addresse)))
-    return sha256((",".join(stations) + f"-{msg_no}").encode()).hexdigest()
+def hash_packet(to: str | None, addresse: str | None, msg_no: str | None) -> str:
+    """Return a deterministic SHA-256 hash for packet deduplication.
+
+    Any ``None`` argument is normalized to the empty string before hashing.
+    This guarantees that packets with missing fields still produce a stable,
+    distinct hash instead of raising ``TypeError`` from sorting ``None``
+    against ``str`` or collapsing unrelated packets into the same degenerate
+    ``"-None"`` hash.
+    """
+    safe_to = to if to is not None else ""
+    safe_addresse = addresse if addresse is not None else ""
+    safe_msg_no = msg_no if msg_no is not None else ""
+    stations = tuple(sorted((safe_to, safe_addresse)))
+    return sha256((",".join(stations) + f"-{safe_msg_no}").encode()).hexdigest()

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -1,0 +1,34 @@
+from aprs_backend.packets.parser import hash_packet
+import pytest
+
+
+def test_hash_is_deterministic():
+    """Same (to, addresse, msg_no) always produces the same hash."""
+    h1 = hash_packet("W1AW", "W2AW", "001")
+    h2 = hash_packet("W1AW", "W2AW", "001")
+    assert h1 == h2
+    assert len(h1) == 64  # sha256 hex digest length
+
+
+def test_hash_normalizes_station_order():
+    """Swapped to/addresse arguments produce the same hash (alphabetically sorted)."""
+    h1 = hash_packet("W2AW", "W1AW", "001")
+    h2 = hash_packet("W1AW", "W2AW", "001")
+    assert h1 == h2
+
+
+def test_hash_uses_lru_cache():
+    """Identical inputs hit the lru_cache on a second call."""
+    hash_packet.cache_clear()
+    hash_packet("W1AW", "W2AW", "001")
+    info_before = hash_packet.cache_info()
+    hash_packet("W1AW", "W2AW", "001")
+    info_after = hash_packet.cache_info()
+    assert info_after.hits == info_before.hits + 1
+
+
+def test_different_inputs_produce_different_hashes():
+    """Different msg_no produces a different hash."""
+    h1 = hash_packet("W1AW", "W2AW", "001")
+    h2 = hash_packet("W1AW", "W2AW", "002")
+    assert h1 != h2

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -39,6 +39,45 @@ def test_different_inputs_produce_different_hashes():
     assert h1 != h2
 
 
+def test_hash_handles_none_to():
+    """None for 'to' is normalized to empty string (no TypeError)."""
+    h = hash_packet(None, "W2AW", "001")
+    assert isinstance(h, str)
+    assert len(h) == 64
+
+
+def test_hash_handles_none_addresse():
+    """None for 'addresse' is normalized to empty string (no TypeError)."""
+    h = hash_packet("W1AW", None, "001")
+    assert isinstance(h, str)
+    assert len(h) == 64
+
+
+def test_hash_handles_none_msg_no():
+    """None for 'msg_no' is normalized to empty string (no TypeError)."""
+    h = hash_packet("W1AW", "W2AW", None)
+    assert isinstance(h, str)
+    assert len(h) == 64
+
+
+def test_hash_handles_all_none():
+    """All-None inputs produce a defined hash instead of a degenerate '-None'."""
+    h = hash_packet(None, None, None)
+    assert isinstance(h, str)
+    assert len(h) == 64
+    # The pre-image is ",".join(("", "")) + "-" + "" = ",-"
+    import hashlib
+    expected = hashlib.sha256(",-".encode()).hexdigest()
+    assert h == expected
+
+
+def test_hash_none_inputs_are_distinct_from_non_none():
+    """A None field produces a different hash than the same call with a value."""
+    h_none = hash_packet(None, "W2AW", "001")
+    h_value = hash_packet("W1AW", "W2AW", "001")
+    assert h_none != h_value
+
+
 @pytest.mark.asyncio
 async def test_process_message_dedup_skips_repeated_packet():
     """The dedup path in _process_message skips a repeated packet (same to/addresse/msgNo)."""

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -1,3 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncio
+import pytest
+
+from aprs_backend.packets import MessagePacket
 from aprs_backend.packets.parser import hash_packet
 
 
@@ -31,3 +37,58 @@ def test_different_inputs_produce_different_hashes():
     h1 = hash_packet("W1AW", "W2AW", "001")
     h2 = hash_packet("W1AW", "W2AW", "002")
     assert h1 != h2
+
+
+@pytest.mark.asyncio
+async def test_process_message_dedup_skips_repeated_packet():
+    """The dedup path in _process_message skips a repeated packet (same to/addresse/msgNo)."""
+    from aprs_backend.aprs import APRSBackend
+
+    # Build two MessagePackets with identical (to, addresse, msgNo)
+    packet1 = MessagePacket(
+        from_call="W1AW",
+        to_call="W2AW",
+        addresse="W2AW",
+        msgNo="001",
+        message_text="hello",
+    )
+    packet2 = MessagePacket(
+        from_call="W1AW",
+        to_call="W2AW",
+        addresse="W2AW",
+        msgNo="001",
+        message_text="hello again",
+    )
+    # A third packet with a different msgNo should NOT be deduplicated
+    packet3 = MessagePacket(
+        from_call="W1AW",
+        to_call="W2AW",
+        addresse="W2AW",
+        msgNo="002",
+        message_text="different message",
+    )
+
+    # Verify both packets produce the same hash
+    h1 = hash_packet(packet1.to, packet1.addresse, packet1.msgNo)
+    h2 = hash_packet(packet2.to, packet2.addresse, packet2.msgNo)
+    assert h1 == h2
+
+    # Mock the APRSBackend minimally to exercise _process_message
+    with patch.object(APRSBackend, "__init__", lambda self, config: None):
+        backend = APRSBackend(None)
+        backend._packet_cache = {}
+        backend._packet_cache_lock = asyncio.Lock()
+        backend._ack_message = AsyncMock()
+        backend.callback_message = MagicMock()
+
+        # First packet should NOT be deduped — callback_message called
+        await backend._process_message(packet1)
+        assert backend.callback_message.call_count == 1
+
+        # Second identical packet SHOULD be deduped — callback_message NOT called again
+        await backend._process_message(packet2)
+        assert backend.callback_message.call_count == 1
+
+        # Third distinct packet should NOT be deduped
+        await backend._process_message(packet3)
+        assert backend.callback_message.call_count == 2

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -1,5 +1,4 @@
 from aprs_backend.packets.parser import hash_packet
-import pytest
 
 
 def test_hash_is_deterministic():

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -8,6 +8,19 @@ from aprs_backend.packets import MessagePacket
 from aprs_backend.packets.parser import hash_packet
 
 
+def _build_minimal_backend():
+    """Factory that partially constructs an APRSBackend with only the
+    attributes required by _process_message's dedup path."""
+    from aprs_backend.aprs import APRSBackend
+
+    backend = object.__new__(APRSBackend)
+    backend._packet_cache = {}
+    backend._packet_cache_lock = asyncio.Lock()
+    backend._ack_message = AsyncMock()
+    backend.callback_message = MagicMock()
+    return backend
+
+
 def test_hash_is_deterministic():
     """Same (to, addresse, msg_no) always produces the same hash."""
     h1 = hash_packet("W1AW", "W2AW", "001")
@@ -81,7 +94,6 @@ def test_hash_none_inputs_are_distinct_from_non_none():
 @pytest.mark.asyncio
 async def test_process_message_dedup_skips_repeated_packet():
     """The dedup path in _process_message skips a repeated packet (same to/addresse/msgNo)."""
-    from aprs_backend.aprs import APRSBackend
 
     # Build two MessagePackets with identical (to, addresse, msgNo)
     packet1 = MessagePacket(
@@ -112,14 +124,13 @@ async def test_process_message_dedup_skips_repeated_packet():
     h2 = hash_packet(packet2.to, packet2.addresse, packet2.msgNo)
     assert h1 == h2
 
-    # Mock the APRSBackend minimally to exercise _process_message
-    with patch.object(APRSBackend, "__init__", lambda self, config: None):
-        backend = APRSBackend(None)
-        backend._packet_cache = {}
-        backend._packet_cache_lock = asyncio.Lock()
-        backend._ack_message = AsyncMock()
-        backend.callback_message = MagicMock()
+    backend = _build_minimal_backend()
 
+    # Mock APRSMessage.from_message_packet so the test depends only on
+    # dedup behavior, not on real APRSMessage/APRSPerson construction.
+    mock_msg = MagicMock()
+    mock_msg.body = "hello"
+    with patch("aprs_backend.aprs.APRSMessage.from_message_packet", return_value=mock_msg):
         # First packet should NOT be deduped — callback_message called
         await backend._process_message(packet1)
         assert backend.callback_message.call_count == 1
@@ -131,3 +142,51 @@ async def test_process_message_dedup_skips_repeated_packet():
         # Third distinct packet should NOT be deduped
         await backend._process_message(packet3)
         assert backend.callback_message.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_dedup_hash_and_cache_isolation():
+    """Focused test of the dedup branch: hash + cache check at aprs.py:458-463.
+
+    This test exercises only the hash computation and cache lookup without
+    depending on the full _process_message dispatch internals (APRSMessage
+    construction, body stripping, callback dispatch, etc.).
+    """
+
+    backend = _build_minimal_backend()
+
+    # Identical packets share the same dedup key
+    packet_dup = MessagePacket(
+        from_call="W1AW",
+        to_call="W2AW",
+        addresse="W2AW",
+        msgNo="001",
+        message_text="dup",
+    )
+    # Distinct packet has a different msgNo
+    packet_distinct = MessagePacket(
+        from_call="W1AW",
+        to_call="W2AW",
+        addresse="W2AW",
+        msgNo="002",
+        message_text="distinct",
+    )
+
+    dup_hash = hash_packet(packet_dup.to, packet_dup.addresse, packet_dup.msgNo)
+    distinct_hash = hash_packet(packet_distinct.to, packet_distinct.addresse, packet_distinct.msgNo)
+    assert dup_hash != distinct_hash
+
+    # Simulate the dedup logic from _process_message lines 458-463:
+    # First packet: hash not in cache, so it is stored.
+    async with backend._packet_cache_lock:
+        assert backend._packet_cache.get(dup_hash, None) is None
+        backend._packet_cache[dup_hash] = packet_dup
+
+    # Second identical packet: hash IS in cache, so it would be skipped.
+    async with backend._packet_cache_lock:
+        assert backend._packet_cache.get(dup_hash, None) is not None
+
+    # Distinct packet: hash not in cache, so it is NOT deduped.
+    async with backend._packet_cache_lock:
+        assert backend._packet_cache.get(distinct_hash, None) is None
+        backend._packet_cache[distinct_hash] = packet_distinct

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -1,6 +1,7 @@
+import asyncio
+import hashlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import asyncio
 import pytest
 
 from aprs_backend.packets import MessagePacket
@@ -66,8 +67,7 @@ def test_hash_handles_all_none():
     assert isinstance(h, str)
     assert len(h) == 64
     # The pre-image is ",".join(("", "")) + "-" + "" = ",-"
-    import hashlib
-    expected = hashlib.sha256(",-".encode()).hexdigest()
+    expected = hashlib.sha256(b",-").hexdigest()
     assert h == expected
 
 


### PR DESCRIPTION
## Summary

Delivers parent issue #440: fix(parser): extract hash_packet cache key to immutable primitive fields

### Child issues integrated

- Closes #502 — Isolate and de-fragile the _process_message dedup test
- Closes #501 — Harden hash_packet() against None inputs and align its type contract
- Closes #500 — fix(parser): key hash_packet lru_cache on immutable primitive string fields

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #440 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`