### PR TITLE
fix(health): log getloadavg exceptions instead of silently swallowing them

### DIFF
--- a/aprs_backend/plugins/health.py
+++ b/aprs_backend/plugins/health.py
@@ -48,7 +48,8 @@ class APRSHealth(BotPlugin):
             from posix import getloadavg
 
             loads = getloadavg()
-        except Exception:
+        except Exception as exc:
+            self.log.debug("getloadavg not available: %s", exc)
             loads = None
 
         return {"loads": loads}


### PR DESCRIPTION
## Summary

Delivers parent issue #446: fix(health): log getloadavg exceptions instead of silently swallowing them


## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #446 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`