### PR TITLE
refactor(aprsis): use instance logger self._log instead of module-level logging.error in get_packet

### DIFF
--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -177,7 +177,7 @@ class APRSISClient:
             # Read packet string from socket
             packet_bytes = await self._reader.readline()
         except Exception as exc:
-            logging.error("Could not read packet: %s", exc)
+            self._log.error("Could not read packet: %s", exc)
             raise APRSISPacketError from exc
 
         if not packet_bytes:


### PR DESCRIPTION
## Summary

Delivers parent issue #448: refactor(aprsis): use instance logger self._log instead of module-level logging.error in get_packet


## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #448 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`