### PR TITLE
refactor(plugins): replace private importlib._bootstrap imports with public importlib.util

### DIFF
--- a/aprs_backend/utils/plugins.py
+++ b/aprs_backend/utils/plugins.py
@@ -5,9 +5,8 @@ import logging
 from errbot.utils import version2tuple
 from configparser import ConfigParser
 from dataclasses import dataclass
-from importlib._bootstrap import module_from_spec
+from importlib.util import spec_from_file_location, module_from_spec
 import inspect
-from importlib._bootstrap_external import spec_from_file_location
 import sys
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

Delivers parent issue #449: refactor(plugins): replace private importlib._bootstrap imports with public importlib.util


## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #449 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`