### PR TITLE
fix(aprsis): add read timeout to sequential readline calls in _send_login

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -70,6 +70,7 @@ class APRSBackend(ErrBot):
             aprs_config["aprs_filter"] = f"g/{aprs_config['callsign']}/{self.callsign}"
             self.listening_callsigns.append(self.callsign)
         aprs_config["connect_timeout"] = float(self._get_from_config("APRS_CONNECT_TIMEOUT", "30.0"))
+        aprs_config["login_read_timeout"] = float(self._get_from_config("APRS_LOGIN_READ_TIMEOUT", "10.0"))
         self._client = APRSISClient(**aprs_config, logger=log)
         self._send_queue: asyncio.Queue[MessagePacket] = asyncio.Queue(
             maxsize=int(self._get_from_config("APRS_SEND_MAX_QUEUE", "2048"))

--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -86,7 +86,7 @@ class APRSISClient:
             self._log.error(str(e))
             await self.disconnect()
             raise
-        except asyncio.TimeoutError as exc:
+        except TimeoutError as exc:
             await self.disconnect()
             self._log.error(
                 "Timed out waiting for APRS-IS login response after %ss",

--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -63,13 +63,9 @@ class APRSISClient:
         self._log.info("Sending login information")
         try:
             await self._send(self._aprs_login)
-            aprs_version = await asyncio.wait_for(
-                self._reader.readline(), timeout=self._login_read_timeout
-            )
+            aprs_version = await asyncio.wait_for(self._reader.readline(), timeout=self._login_read_timeout)
             aprs_version = aprs_version.decode("latin-1").rstrip()
-            aprs_login_test = await asyncio.wait_for(
-                self._reader.readline(), timeout=self._login_read_timeout
-            )
+            aprs_login_test = await asyncio.wait_for(self._reader.readline(), timeout=self._login_read_timeout)
             aprs_login_test = aprs_login_test.decode("latin-1").rstrip()
             self._log.debug("APRS server version Response %s", aprs_version)
             _, _, callsign, status, _, server = aprs_login_test.split(" ", 5)

--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -25,6 +25,7 @@ class APRSISClient:
         logger: logging.Logger | None = None,
         keepalive_seconds: int = 120,
         connect_timeout: float = 30.0,
+        login_read_timeout: float = 10.0,
     ):
         self.callsign = callsign
         self.password = password
@@ -35,6 +36,7 @@ class APRSISClient:
         self._app_version = app_version
         self._keepalive_seconds = keepalive_seconds
         self._connect_timeout = connect_timeout
+        self._login_read_timeout = login_read_timeout
 
         self._log = logger if logger is not None else logging.getLogger(__name__)
 
@@ -61,9 +63,13 @@ class APRSISClient:
         self._log.info("Sending login information")
         try:
             await self._send(self._aprs_login)
-            aprs_version = await self._reader.readline()
+            aprs_version = await asyncio.wait_for(
+                self._reader.readline(), timeout=self._login_read_timeout
+            )
             aprs_version = aprs_version.decode("latin-1").rstrip()
-            aprs_login_test = await self._reader.readline()
+            aprs_login_test = await asyncio.wait_for(
+                self._reader.readline(), timeout=self._login_read_timeout
+            )
             aprs_login_test = aprs_login_test.decode("latin-1").rstrip()
             self._log.debug("APRS server version Response %s", aprs_version)
             _, _, callsign, status, _, server = aprs_login_test.split(" ", 5)

--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -86,6 +86,15 @@ class APRSISClient:
             self._log.error(str(e))
             await self.disconnect()
             raise
+        except asyncio.TimeoutError as exc:
+            await self.disconnect()
+            self._log.error(
+                "Timed out waiting for APRS-IS login response after %ss",
+                self._login_read_timeout,
+            )
+            raise APRSISLoginError(
+                f"Timed out waiting for APRS-IS login response after {self._login_read_timeout}s"
+            ) from exc
         except Exception as exc:
             await self.disconnect()
             self._log.error("Failed to login %s", str(exc))

--- a/docker/config.py
+++ b/docker/config.py
@@ -41,6 +41,7 @@ APRS_STRIP_NEWLINES = os.environ.get("APRS_STRIP_NEWLINES", "true")
 APRS_LANGUAGE_FILTER = os.environ.get("APRS_LANGUAGE_FILTER", "true")
 APRS_LANGUAGE_FILTER_EXTRA_WORDS = os.environ.get("APRS_LANGUAGE_FILTER_EXTRA_WORDS", "").strip(",").split(",")
 APRS_CONNECT_TIMEOUT = os.environ.get("APRS_CONNECT_TIMEOUT", "30.0")
+APRS_LOGIN_READ_TIMEOUT = os.environ.get("APRS_LOGIN_READ_TIMEOUT", "10.0")
 
 APRS_REGISTRY_ENABLED = os.environ.get("APRS_REGISTRY_ENABLED", "false").lower()
 APRS_REGISTRY_URL = os.environ.get("APRS_REGISTRY_URL", "https://aprs.hemna.com/api/v1/registry")

--- a/tests/clients/test_aprsis.py
+++ b/tests/clients/test_aprsis.py
@@ -186,7 +186,7 @@ async def test_login_read_timeout_used_in_wait_for(mock_logger):
         wait_for_calls.append(timeout)
         if call_count[0] == 1:
             return b"APRS-IS Linux 3.0.19+gcc12.2.0"
-        raise asyncio.TimeoutError("mock timeout")
+        raise TimeoutError("mock timeout")
 
     mock_reader = MagicMock()
     mock_reader.readline = AsyncMock()

--- a/tests/clients/test_aprsis.py
+++ b/tests/clients/test_aprsis.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aprs_backend.clients import APRSISClient
-from aprs_backend.exceptions.client.aprsis import APRSISConnnectError
+from aprs_backend.exceptions.client.aprsis import APRSISConnnectError, APRSISLoginError
 
 
 @pytest.fixture
@@ -148,3 +148,89 @@ async def test_disconnect_resets_state_when_wait_closed_raises(mock_logger):
     assert client._writer is None
     assert client._reader is None
     assert client.connected is False
+
+
+def test_default_login_read_timeout(aprsis_client):
+    """Default login read timeout should be 10 seconds."""
+    assert aprsis_client._login_read_timeout == 10.0
+
+
+def test_custom_login_read_timeout(mock_logger):
+    """Custom login read timeout should be respected."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        login_read_timeout=20.0,
+        logger=mock_logger,
+    )
+    assert client._login_read_timeout == 20.0
+
+
+@pytest.mark.asyncio
+async def test_login_read_timeout_used_in_wait_for(mock_logger):
+    """asyncio.wait_for should be called with the configured login_read_timeout."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        host="test.aprs2.net",
+        port=14580,
+        login_read_timeout=15.0,
+        logger=mock_logger,
+    )
+
+    wait_for_calls = []
+    call_count = [0]
+
+    async def mock_wait_for(coro, timeout=None):
+        call_count[0] += 1
+        wait_for_calls.append(timeout)
+        if call_count[0] == 1:
+            return b"APRS-IS Linux 3.0.19+gcc12.2.0"
+        raise asyncio.TimeoutError("mock timeout")
+
+    mock_reader = MagicMock()
+    mock_reader.readline = AsyncMock()
+    client._reader = mock_reader
+    mock_writer = MagicMock()
+    mock_writer.wait_closed = AsyncMock()
+    client._writer = mock_writer
+    client._writer.write = MagicMock()
+    client._writer.drain = AsyncMock()
+
+    with patch.object(asyncio, "wait_for", mock_wait_for):
+        with pytest.raises(APRSISLoginError):
+            await client._send_login()
+
+    # Both readline calls should be wrapped with the configured timeout
+    assert len(wait_for_calls) == 2
+    assert wait_for_calls[0] == 15.0
+    assert wait_for_calls[1] == 15.0
+
+
+@pytest.mark.asyncio
+async def test_login_read_timeout_raises_on_slow_server(mock_logger):
+    """When readline times out, APRSISLoginError should be raised."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        host="test.aprs2.net",
+        port=14580,
+        login_read_timeout=0.1,
+        logger=mock_logger,
+    )
+
+    async def slow_readline():
+        await asyncio.sleep(10)
+        return b"version"
+
+    mock_reader = MagicMock()
+    mock_reader.readline = slow_readline
+    client._reader = mock_reader
+    mock_writer = MagicMock()
+    mock_writer.wait_closed = AsyncMock()
+    client._writer = mock_writer
+    client._writer.write = MagicMock()
+    client._writer.drain = AsyncMock()
+
+    with pytest.raises(APRSISLoginError, match="Failed to login"):
+        await client._send_login()

--- a/tests/clients/test_aprsis.py
+++ b/tests/clients/test_aprsis.py
@@ -232,5 +232,5 @@ async def test_login_read_timeout_raises_on_slow_server(mock_logger):
     client._writer.write = MagicMock()
     client._writer.drain = AsyncMock()
 
-    with pytest.raises(APRSISLoginError, match="Failed to login"):
+    with pytest.raises(APRSISLoginError, match="Timed out waiting for APRS-IS login response after 0.1s"):
         await client._send_login()

--- a/tests/test_docker_config.py
+++ b/tests/test_docker_config.py
@@ -3,6 +3,7 @@
 This guards against the Docker config surface drifting out of sync with the
 keys consumed by aprs_backend/aprs.py.
 """
+
 import importlib
 import sys
 import os
@@ -27,12 +28,8 @@ def test_docker_config_exposes_aprs_login_read_timeout():
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
 
-        assert hasattr(mod, "APRS_LOGIN_READ_TIMEOUT"), (
-            "docker/config.py must expose APRS_LOGIN_READ_TIMEOUT"
-        )
-        assert mod.APRS_LOGIN_READ_TIMEOUT == "10.0", (
-            "APRS_LOGIN_READ_TIMEOUT default must be '10.0' to match aprs.py"
-        )
+        assert hasattr(mod, "APRS_LOGIN_READ_TIMEOUT"), "docker/config.py must expose APRS_LOGIN_READ_TIMEOUT"
+        assert mod.APRS_LOGIN_READ_TIMEOUT == "10.0", "APRS_LOGIN_READ_TIMEOUT default must be '10.0' to match aprs.py"
     finally:
         for var, old_val in env_backup.items():
             if old_val is None:
@@ -57,9 +54,7 @@ def test_docker_config_aprs_login_read_timeout_honors_env():
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
 
-        assert mod.APRS_LOGIN_READ_TIMEOUT == "20.0", (
-            "docker/config.py must honor the APRS_LOGIN_READ_TIMEOUT env var"
-        )
+        assert mod.APRS_LOGIN_READ_TIMEOUT == "20.0", "docker/config.py must honor the APRS_LOGIN_READ_TIMEOUT env var"
     finally:
         for var, old_val in env_backup.items():
             if old_val is None:

--- a/tests/test_docker_config.py
+++ b/tests/test_docker_config.py
@@ -1,0 +1,70 @@
+"""Regression test: docker/config.py must expose APRS_* keys read via _get_from_config in aprs.py.
+
+This guards against the Docker config surface drifting out of sync with the
+keys consumed by aprs_backend/aprs.py.
+"""
+import importlib
+import sys
+import types
+import os
+from pathlib import Path
+
+
+def test_docker_config_exposes_aprs_login_read_timeout():
+    """docker/config.py must define APRS_LOGIN_READ_TIMEOUT so that
+    _get_from_config("APRS_LOGIN_READ_TIMEOUT", ...) in aprs.py resolves
+    the env var instead of silently falling through to the default."""
+
+    # Load docker/config.py as a module.  It calls sys.exit(1) when
+    # APRS_CALLSIGN / APRS_PASSWORD are missing, so stub those env vars.
+    env_backup = {}
+    for var in ("APRS_CALLSIGN", "APRS_PASSWORD"):
+        env_backup[var] = os.environ.get(var)
+        os.environ[var] = os.environ.get(var, "TEST")
+
+    try:
+        config_path = Path(__file__).resolve().parent.parent / "docker" / "config.py"
+        spec = importlib.util.spec_from_file_location("docker_config", config_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        assert hasattr(mod, "APRS_LOGIN_READ_TIMEOUT"), (
+            "docker/config.py must expose APRS_LOGIN_READ_TIMEOUT"
+        )
+        assert mod.APRS_LOGIN_READ_TIMEOUT == "10.0", (
+            "APRS_LOGIN_READ_TIMEOUT default must be '10.0' to match aprs.py"
+        )
+    finally:
+        for var, old_val in env_backup.items():
+            if old_val is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = old_val
+        sys.modules.pop("docker_config", None)
+
+
+def test_docker_config_aprs_login_read_timeout_honors_env():
+    """When APRS_LOGIN_READ_TIMEOUT is set in the environment, docker/config.py
+    must reflect that value (not the default)."""
+
+    env_backup = {}
+    for var in ("APRS_CALLSIGN", "APRS_PASSWORD", "APRS_LOGIN_READ_TIMEOUT"):
+        env_backup[var] = os.environ.get(var)
+        os.environ[var] = os.environ.get(var, "TEST" if var != "APRS_LOGIN_READ_TIMEOUT" else "20.0")
+
+    try:
+        config_path = Path(__file__).resolve().parent.parent / "docker" / "config.py"
+        spec = importlib.util.spec_from_file_location("docker_config_env", config_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        assert mod.APRS_LOGIN_READ_TIMEOUT == "20.0", (
+            "docker/config.py must honor the APRS_LOGIN_READ_TIMEOUT env var"
+        )
+    finally:
+        for var, old_val in env_backup.items():
+            if old_val is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = old_val
+        sys.modules.pop("docker_config_env", None)

--- a/tests/test_docker_config.py
+++ b/tests/test_docker_config.py
@@ -5,7 +5,6 @@ keys consumed by aprs_backend/aprs.py.
 """
 import importlib
 import sys
-import types
 import os
 from pathlib import Path
 

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.1.0,<4" },
     { name = "pyupgrade", specifier = ">=3.15.2,<4" },
     { name = "reorder-python-imports", specifier = ">=3.9.0,<4" },
-    { name = "ruff", specifier = ">=0.5.1,<0.14.6" },
+    { name = "ruff", specifier = ">=0.5.1,<0.16.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Delivers parent issue #450: fix(aprsis): add read timeout to sequential readline calls in _send_login

### Child issues integrated

- Closes #510 — Make APRS-IS login-read timeout produce a diagnostic log line and exception message
- Closes #509 — Wire APRS_LOGIN_READ_TIMEOUT into docker/config.py alongside APRS_CONNECT_TIMEOUT

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #450 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`