### PR TITLE
fix(aprsis): add read timeout to get_packet readline to prevent indefinite hang on stalled connections

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -13,6 +13,7 @@ from aprs_backend.exceptions import (
     ProcessorError,
     PacketParseError,
     APRSISConnnectError,
+    APRSISDeadConnectionError,
 )
 from aprs_backend.packets.parser import parse, hash_packet
 from expiringdict import ExpiringDict
@@ -71,6 +72,7 @@ class APRSBackend(ErrBot):
             self.listening_callsigns.append(self.callsign)
         aprs_config["connect_timeout"] = float(self._get_from_config("APRS_CONNECT_TIMEOUT", "30.0"))
         aprs_config["login_read_timeout"] = float(self._get_from_config("APRS_LOGIN_READ_TIMEOUT", "10.0"))
+        aprs_config["read_timeout"] = float(self._get_from_config("APRS_READ_TIMEOUT", "180.0"))
         self._client = APRSISClient(**aprs_config, logger=log)
         self._send_queue: asyncio.Queue[MessagePacket] = asyncio.Queue(
             maxsize=int(self._get_from_config("APRS_SEND_MAX_QUEUE", "2048"))
@@ -358,6 +360,10 @@ class APRSBackend(ErrBot):
         except KeyboardInterrupt:
             log.info("Interrupt received, shutting down..")
             return True
+        except APRSISDeadConnectionError as exc:
+            log.warning("Dead connection detected, disconnecting: %s", exc)
+            await self._client.disconnect()
+            return False
         except Exception as exc:
             log.error("Fatal unhandled error reading from APRS %s", exc)
             return False

--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -26,6 +26,7 @@ class APRSISClient:
         keepalive_seconds: int = 120,
         connect_timeout: float = 30.0,
         login_read_timeout: float = 10.0,
+        read_timeout: float = 180.0,
     ):
         self.callsign = callsign
         self.password = password
@@ -37,6 +38,7 @@ class APRSISClient:
         self._keepalive_seconds = keepalive_seconds
         self._connect_timeout = connect_timeout
         self._login_read_timeout = login_read_timeout
+        self._read_timeout = read_timeout
 
         self._log = logger if logger is not None else logging.getLogger(__name__)
 
@@ -185,8 +187,13 @@ class APRSISClient:
         if not self.connected:
             raise APRSISConnnectError("Not connected")
         try:
-            # Read packet string from socket
-            packet_bytes = await self._reader.readline()
+            # Read packet string from socket with timeout to prevent indefinite hang
+            packet_bytes = await asyncio.wait_for(self._reader.readline(), timeout=self._read_timeout)
+        except asyncio.TimeoutError:
+            self._log.error("Read timeout after %s seconds. Connection may be stalled.", self._read_timeout)
+            raise APRSISDeadConnectionError(
+                f"Read timeout after {self._read_timeout} seconds. Connection may be stalled."
+            )
         except Exception as exc:
             self._log.error("Could not read packet: %s", exc)
             raise APRSISPacketError from exc

--- a/aprs_backend/clients/aprsis.py
+++ b/aprs_backend/clients/aprsis.py
@@ -189,7 +189,7 @@ class APRSISClient:
         try:
             # Read packet string from socket with timeout to prevent indefinite hang
             packet_bytes = await asyncio.wait_for(self._reader.readline(), timeout=self._read_timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._log.error("Read timeout after %s seconds. Connection may be stalled.", self._read_timeout)
             raise APRSISDeadConnectionError(
                 f"Read timeout after {self._read_timeout} seconds. Connection may be stalled."

--- a/docker/config.py
+++ b/docker/config.py
@@ -42,6 +42,7 @@ APRS_LANGUAGE_FILTER = os.environ.get("APRS_LANGUAGE_FILTER", "true")
 APRS_LANGUAGE_FILTER_EXTRA_WORDS = os.environ.get("APRS_LANGUAGE_FILTER_EXTRA_WORDS", "").strip(",").split(",")
 APRS_CONNECT_TIMEOUT = os.environ.get("APRS_CONNECT_TIMEOUT", "30.0")
 APRS_LOGIN_READ_TIMEOUT = os.environ.get("APRS_LOGIN_READ_TIMEOUT", "10.0")
+APRS_READ_TIMEOUT = os.environ.get("APRS_READ_TIMEOUT", "180.0")
 
 APRS_REGISTRY_ENABLED = os.environ.get("APRS_REGISTRY_ENABLED", "false").lower()
 APRS_REGISTRY_URL = os.environ.get("APRS_REGISTRY_URL", "https://aprs.hemna.com/api/v1/registry")

--- a/tests/clients/test_aprsis.py
+++ b/tests/clients/test_aprsis.py
@@ -3,7 +3,11 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aprs_backend.clients import APRSISClient
-from aprs_backend.exceptions.client.aprsis import APRSISConnnectError, APRSISLoginError
+from aprs_backend.exceptions.client.aprsis import (
+    APRSISConnnectError,
+    APRSISLoginError,
+    APRSISDeadConnectionError,
+)
 
 
 @pytest.fixture
@@ -234,3 +238,94 @@ async def test_login_read_timeout_raises_on_slow_server(mock_logger):
 
     with pytest.raises(APRSISLoginError, match="Timed out waiting for APRS-IS login response after 0.1s"):
         await client._send_login()
+
+
+def test_default_read_timeout(aprsis_client):
+    """Default read timeout should be 180 seconds."""
+    assert aprsis_client._read_timeout == 180.0
+
+
+def test_custom_read_timeout(mock_logger):
+    """Custom read timeout should be respected."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        read_timeout=120.0,
+        logger=mock_logger,
+    )
+    assert client._read_timeout == 120.0
+
+
+@pytest.mark.asyncio
+async def test_get_packet_read_timeout_raises_dead_connection(mock_logger):
+    """get_packet() should raise APRSISDeadConnectionError on read timeout."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        read_timeout=0.1,
+        logger=mock_logger,
+    )
+    client.connected = True
+
+    mock_reader = AsyncMock()
+
+    # Simulate a stall: readline never returns
+    async def hanging_readline():
+        await asyncio.sleep(10)
+        return b"test"
+
+    mock_reader.readline = hanging_readline
+    client._reader = mock_reader
+
+    with pytest.raises(APRSISDeadConnectionError) as exc_info:
+        await client.get_packet()
+
+    assert "timeout" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_get_packet_read_timeout_value_used_in_wait_for(mock_logger):
+    """asyncio.wait_for should be called with the configured read timeout."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        read_timeout=45.0,
+        logger=mock_logger,
+    )
+    client.connected = True
+
+    wait_for_called_with = {}
+
+    async def mock_wait_for(coro, timeout=None):
+        wait_for_called_with["timeout"] = timeout
+        raise asyncio.TimeoutError("mock timeout")
+
+    mock_reader = AsyncMock()
+    client._reader = mock_reader
+
+    with patch.object(asyncio, "wait_for", mock_wait_for):
+        with pytest.raises(APRSISDeadConnectionError):
+            await client.get_packet()
+
+    assert wait_for_called_with["timeout"] == 45.0
+
+
+@pytest.mark.asyncio
+async def test_get_packet_successful_read(mock_logger):
+    """get_packet() should return decoded packet on successful read."""
+    client = APRSISClient(
+        callsign="TEST-1",
+        password="1234",
+        read_timeout=10.0,
+        logger=mock_logger,
+    )
+    client.connected = True
+
+    mock_reader = AsyncMock()
+    mock_reader.readline.return_value = b"TEST-1>USER-1:Hello\r\n"
+    client._reader = mock_reader
+
+    result = await client.get_packet()
+
+    assert result == "TEST-1>USER-1:Hello\r\n"
+    mock_reader.readline.assert_awaited_once()

--- a/tests/clients/test_aprsis.py
+++ b/tests/clients/test_aprsis.py
@@ -298,7 +298,7 @@ async def test_get_packet_read_timeout_value_used_in_wait_for(mock_logger):
 
     async def mock_wait_for(coro, timeout=None):
         wait_for_called_with["timeout"] = timeout
-        raise asyncio.TimeoutError("mock timeout")
+        raise TimeoutError("mock timeout")
 
     mock_reader = AsyncMock()
     client._reader = mock_reader

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,5 +9,6 @@ def mock_logger():
             self.debug = MagicMock()
             self.error = MagicMock()
             self.info = MagicMock()
+            self.warning = MagicMock()
 
     return MockLogger()

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -65,20 +65,6 @@ def backend(bot_config):
     return backend
 
 
-@pytest.fixture
-def mock_logger():
-    """Mock logger with warning method for APRSBackend tests."""
-
-    class MockLogger:
-        def __init__(self):
-            self.debug = MagicMock()
-            self.error = MagicMock()
-            self.info = MagicMock()
-            self.warning = MagicMock()
-
-    return MockLogger()
-
-
 def _make_packet(msgno: int = 1, last_send_attempt: int = 0, last_send_time: datetime | None = None):
     """Helper to create a MessagePacket for _waiting_ack."""
     pkt = MessagePacket(
@@ -435,26 +421,30 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
 
 
 @pytest.mark.asyncio
-async def test_receive_worker_handles_dead_connection(mock_logger):
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Read timeout",
+        "Empty packet received. Probably missed keepalives",
+    ],
+    ids=["timeout", "empty_packet"],
+)
+async def test_receive_worker_handles_dead_connection(mock_logger, error_message):
     """receive_worker catches APRSISDeadConnectionError, calls disconnect(), logs at warning level, and returns False."""
 
     # Create a mock backend with the minimal attributes receive_worker needs
     backend = MagicMock(spec=[])
     backend._client = AsyncMock()
     backend._client.connect = AsyncMock()
-    backend._client.get_packet = AsyncMock(side_effect=APRSISDeadConnectionError("Read timeout"))
+    backend._client.get_packet = AsyncMock(side_effect=APRSISDeadConnectionError(error_message))
     backend._client.disconnect = AsyncMock()
     backend.listening_callsigns = ["TEST-1"]
     backend._dropped_packets = 0
     backend._max_dropped_packets = 25
     backend.process_packet = AsyncMock()
-    backend._get_from_config = MagicMock(return_value="false")
 
     # Bind the real receive_worker method to the mock
     with patch("aprs_backend.aprs.log", mock_logger):
-        from aprs_backend.aprs import APRSBackend
-
-        # Bind the actual method onto our mock object
         receive_worker_method = APRSBackend.receive_worker.__get__(backend, type(backend))
         result = await receive_worker_method()
 
@@ -471,37 +461,3 @@ async def test_receive_worker_handles_dead_connection(mock_logger):
     # Assert a warning was logged about the dead connection
     warning_calls = [call for call in mock_logger.warning.call_args_list if "Dead connection" in str(call)]
     assert len(warning_calls) == 1, f"Expected one warning about dead connection, got: {warning_calls}"
-
-
-@pytest.mark.asyncio
-async def test_receive_worker_dead_connection_empty_packet(mock_logger):
-    """receive_worker handles APRSISDeadConnectionError from empty packet source identically."""
-
-    backend = MagicMock(spec=[])
-    backend._client = AsyncMock()
-    backend._client.connect = AsyncMock()
-    backend._client.get_packet = AsyncMock(
-        side_effect=APRSISDeadConnectionError("Empty packet received. Probably missed keepalives")
-    )
-    backend._client.disconnect = AsyncMock()
-    backend.listening_callsigns = ["TEST-1"]
-    backend._dropped_packets = 0
-    backend._max_dropped_packets = 25
-    backend.process_packet = AsyncMock()
-
-    with patch("aprs_backend.aprs.log", mock_logger):
-        from aprs_backend.aprs import APRSBackend
-
-        receive_worker_method = APRSBackend.receive_worker.__get__(backend, type(backend))
-        result = await receive_worker_method()
-
-    assert result is False
-    backend._client.disconnect.assert_awaited_once()
-
-    fatal_calls = [
-        call for call in mock_logger.error.call_args_list if "Fatal unhandled error reading from APRS" in str(call)
-    ]
-    assert len(fatal_calls) == 0
-
-    warning_calls = [call for call in mock_logger.warning.call_args_list if "Dead connection" in str(call)]
-    assert len(warning_calls) == 1

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -6,6 +6,7 @@ import pytest
 
 from aprs_backend.aprs import APRSBackend
 from aprs_backend.packets import MessagePacket
+from aprs_backend.exceptions.client.aprsis import APRSISDeadConnectionError
 
 
 class InstrumentedLock:
@@ -62,6 +63,20 @@ def backend(bot_config):
     # Mock send_message to avoid needing a live plugin_manager
     backend.send_message = MagicMock()
     return backend
+
+
+@pytest.fixture
+def mock_logger():
+    """Mock logger with warning method for APRSBackend tests."""
+
+    class MockLogger:
+        def __init__(self):
+            self.debug = MagicMock()
+            self.error = MagicMock()
+            self.info = MagicMock()
+            self.warning = MagicMock()
+
+    return MockLogger()
 
 
 def _make_packet(msgno: int = 1, last_send_attempt: int = 0, last_send_time: datetime | None = None):
@@ -412,3 +427,81 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
 
     # No error-level log should be emitted for the expected concurrent removal
     mock_log.error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: receive_worker dead-connection handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_worker_handles_dead_connection(mock_logger):
+    """receive_worker catches APRSISDeadConnectionError, calls disconnect(), logs at warning level, and returns False."""
+
+    # Create a mock backend with the minimal attributes receive_worker needs
+    backend = MagicMock(spec=[])
+    backend._client = AsyncMock()
+    backend._client.connect = AsyncMock()
+    backend._client.get_packet = AsyncMock(side_effect=APRSISDeadConnectionError("Read timeout"))
+    backend._client.disconnect = AsyncMock()
+    backend.listening_callsigns = ["TEST-1"]
+    backend._dropped_packets = 0
+    backend._max_dropped_packets = 25
+    backend.process_packet = AsyncMock()
+    backend._get_from_config = MagicMock(return_value="false")
+
+    # Bind the real receive_worker method to the mock
+    with patch("aprs_backend.aprs.log", mock_logger):
+        from aprs_backend.aprs import APRSBackend
+
+        # Bind the actual method onto our mock object
+        receive_worker_method = APRSBackend.receive_worker.__get__(backend, type(backend))
+        result = await receive_worker_method()
+
+    # Assert the recovery contract
+    assert result is False
+    backend._client.disconnect.assert_awaited_once()
+
+    # Assert no fatal error was logged
+    fatal_calls = [
+        call for call in mock_logger.error.call_args_list if "Fatal unhandled error reading from APRS" in str(call)
+    ]
+    assert len(fatal_calls) == 0, f"Fatal error was logged: {fatal_calls}"
+
+    # Assert a warning was logged about the dead connection
+    warning_calls = [call for call in mock_logger.warning.call_args_list if "Dead connection" in str(call)]
+    assert len(warning_calls) == 1, f"Expected one warning about dead connection, got: {warning_calls}"
+
+
+@pytest.mark.asyncio
+async def test_receive_worker_dead_connection_empty_packet(mock_logger):
+    """receive_worker handles APRSISDeadConnectionError from empty packet source identically."""
+
+    backend = MagicMock(spec=[])
+    backend._client = AsyncMock()
+    backend._client.connect = AsyncMock()
+    backend._client.get_packet = AsyncMock(
+        side_effect=APRSISDeadConnectionError("Empty packet received. Probably missed keepalives")
+    )
+    backend._client.disconnect = AsyncMock()
+    backend.listening_callsigns = ["TEST-1"]
+    backend._dropped_packets = 0
+    backend._max_dropped_packets = 25
+    backend.process_packet = AsyncMock()
+
+    with patch("aprs_backend.aprs.log", mock_logger):
+        from aprs_backend.aprs import APRSBackend
+
+        receive_worker_method = APRSBackend.receive_worker.__get__(backend, type(backend))
+        result = await receive_worker_method()
+
+    assert result is False
+    backend._client.disconnect.assert_awaited_once()
+
+    fatal_calls = [
+        call for call in mock_logger.error.call_args_list if "Fatal unhandled error reading from APRS" in str(call)
+    ]
+    assert len(fatal_calls) == 0
+
+    warning_calls = [call for call in mock_logger.warning.call_args_list if "Dead connection" in str(call)]
+    assert len(warning_calls) == 1


### PR DESCRIPTION
## Summary

Delivers parent issue #455: fix(aprsis): add read timeout to get_packet readline to prevent indefinite hang on stalled connections

### Child issues integrated

- Closes #512 — Fix or document read_timeout vs keepalive_seconds default relationship
- Closes #511 — Add explicit reconnect/retry handling for APRSISDeadConnectionError in receive_worker

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #455 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`