### PR TITLE
perf(aprs): change listening_callsigns from list to set for O(1) membership lookup

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -62,14 +62,14 @@ class APRSBackend(ErrBot):
             log.fatal("No password in bot identity")
             sys.exit(1)
 
-        self.listening_callsigns = [aprs_config["callsign"]]
+        self.listening_callsigns = {aprs_config["callsign"]}
 
         self.callsign = self._get_from_config("APRS_BOT_CALLSIGN", aprs_config["callsign"])
         self.bot_identifier = APRSPerson(self.callsign)
         if self.callsign != aprs_config["callsign"]:
             # bot is using a different callsign from the signin, add it to the filter
             aprs_config["aprs_filter"] = f"g/{aprs_config['callsign']}/{self.callsign}"
-            self.listening_callsigns.append(self.callsign)
+            self.listening_callsigns.add(self.callsign)
         aprs_config["connect_timeout"] = float(self._get_from_config("APRS_CONNECT_TIMEOUT", "30.0"))
         aprs_config["login_read_timeout"] = float(self._get_from_config("APRS_LOGIN_READ_TIMEOUT", "10.0"))
         aprs_config["read_timeout"] = float(self._get_from_config("APRS_READ_TIMEOUT", "180.0"))

--- a/aprs_backend/clients/aprs_registry.py
+++ b/aprs_backend/clients/aprs_registry.py
@@ -8,7 +8,7 @@ from logging import Logger
 @dataclass
 class RegistryAppConfig:
     description: str
-    listening_callsigns: list[str]
+    listening_callsigns: set[str]
     website: str = ""
     software: str = ""
 

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -9,14 +9,14 @@ import httpx
 @pytest.fixture
 def registry_app_config():
     return RegistryAppConfig(
-        description="description", listening_callsigns=["TEST-1"], website="website", software="software"
+        description="description", listening_callsigns={"TEST-1"}, website="website", software="software"
     )
 
 
 parameters = [
-    ("testing", ["TEST-1"], "http://test.test", "testsoftware"),
-    ("testing", ["TEST-1", "TEST-2"], "http://test.test", "testsoftware"),
-    ("testing", ["TEST-1", "TEST-2", "EMLSRVR"], "https://test.test", "othersoftware"),
+    ("testing", {"TEST-1"}, "http://test.test", "testsoftware"),
+    ("testing", {"TEST-1", "TEST-2"}, "http://test.test", "testsoftware"),
+    ("testing", {"TEST-1", "TEST-2", "EMLSRVR"}, "https://test.test", "othersoftware"),
 ]
 
 


### PR DESCRIPTION
## Summary

Delivers parent issue #438: perf(aprs): change listening_callsigns from list to set for O(1) membership lookup


## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #438 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`