### PR TITLE
perf(aprs-registry): use asyncio.gather for concurrent POST requests instead of sequential loop

### DIFF
--- a/aprs_backend/clients/aprs_registry.py
+++ b/aprs_backend/clients/aprs_registry.py
@@ -60,24 +60,6 @@ class APRSRegistryClient(ClientBase):
     async def _post_and_log(self, client: httpx.AsyncClient, post_json: dict) -> None:
         """Send a single POST to the registry and log the result."""
         self.log.debug("Posting %s to %s", post_json, self.registry_url)
-        try:
-            response = await client.post(self.registry_url, json=post_json)
-            self.log.debug(response)
-            response.raise_for_status()
-        except httpx.RequestError as exc:
-            self.log.error(
-                "Request Error while posting %s to %s. Error: %s",
-                post_json,
-                self.registry_url,
-                exc,
-            )
-            raise
-        except httpx.HTTPStatusError as exc:
-            self.log.error(
-                "Error while posting %s to %s. Error: %s, response: %s",
-                post_json,
-                self.registry_url,
-                exc,
-                response,
-            )
-            raise
+        response = await client.post(self.registry_url, json=post_json)
+        self.log.debug(response)
+        response.raise_for_status()

--- a/aprs_backend/clients/aprs_registry.py
+++ b/aprs_backend/clients/aprs_registry.py
@@ -51,14 +51,22 @@ class APRSRegistryClient(ClientBase):
             )
             for post_json, result in zip(self.app_config.post_jsons, results):
                 if isinstance(result, Exception):
-                    self.log.error(
-                        "Registry POST failed for %s: %s",
-                        post_json,
-                        result,
-                    )
+                    if isinstance(result, httpx.HTTPStatusError):
+                        self.log.error(
+                            "Registry POST failed for %s: %s, response: %s",
+                            post_json,
+                            result,
+                            result.response,
+                        )
+                    else:
+                        self.log.error(
+                            "Registry POST failed for %s: %s",
+                            post_json,
+                            result,
+                        )
 
     async def _post_and_log(self, client: httpx.AsyncClient, post_json: dict) -> None:
-        """Send a single POST to the registry and log the result."""
+        """Send a single POST to the registry, log debug info, and raise on HTTP errors."""
         self.log.debug("Posting %s to %s", post_json, self.registry_url)
         response = await client.post(self.registry_url, json=post_json)
         self.log.debug(response)

--- a/aprs_backend/clients/aprs_registry.py
+++ b/aprs_backend/clients/aprs_registry.py
@@ -46,10 +46,7 @@ class APRSRegistryClient(ClientBase):
         """
         async with httpx.AsyncClient(timeout=httpx.Timeout(self.timeout_seconds)) as client:
             results = await asyncio.gather(
-                *(
-                    self._post_and_log(client, post_json)
-                    for post_json in self.app_config.post_jsons
-                ),
+                *(self._post_and_log(client, post_json) for post_json in self.app_config.post_jsons),
                 return_exceptions=True,
             )
             for post_json, result in zip(self.app_config.post_jsons, results):

--- a/aprs_backend/clients/aprs_registry.py
+++ b/aprs_backend/clients/aprs_registry.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 import httpx
 from functools import cached_property
@@ -44,24 +45,42 @@ class APRSRegistryClient(ClientBase):
         Run as an asyncio task in __call__
         """
         async with httpx.AsyncClient(timeout=httpx.Timeout(self.timeout_seconds)) as client:
-            for post_json in self.app_config.post_jsons:
-                self.log.debug("Posting %s to %s", post_json, self.registry_url)
-                try:
-                    response = await client.post(self.registry_url, json=post_json)
-                    self.log.debug(response)
-                    response.raise_for_status()
-                except httpx.RequestError as exc:
+            results = await asyncio.gather(
+                *(
+                    self._post_and_log(client, post_json)
+                    for post_json in self.app_config.post_jsons
+                ),
+                return_exceptions=True,
+            )
+            for post_json, result in zip(self.app_config.post_jsons, results):
+                if isinstance(result, Exception):
                     self.log.error(
-                        "Request Error while posting %s to %s. Error: %s",
+                        "Registry POST failed for %s: %s",
                         post_json,
-                        self.registry_url,
-                        exc,
+                        result,
                     )
-                except httpx.HTTPStatusError as exc:
-                    self.log.error(
-                        "Error while posting %s to %s. Error: %s, response: %s",
-                        post_json,
-                        self.registry_url,
-                        exc,
-                        response,
-                    )
+
+    async def _post_and_log(self, client: httpx.AsyncClient, post_json: dict) -> None:
+        """Send a single POST to the registry and log the result."""
+        self.log.debug("Posting %s to %s", post_json, self.registry_url)
+        try:
+            response = await client.post(self.registry_url, json=post_json)
+            self.log.debug(response)
+            response.raise_for_status()
+        except httpx.RequestError as exc:
+            self.log.error(
+                "Request Error while posting %s to %s. Error: %s",
+                post_json,
+                self.registry_url,
+                exc,
+            )
+            raise
+        except httpx.HTTPStatusError as exc:
+            self.log.error(
+                "Error while posting %s to %s. Error: %s, response: %s",
+                post_json,
+                self.registry_url,
+                exc,
+                response,
+            )
+            raise

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -222,9 +222,7 @@ async def test_APRSRegistryClient_one_failure_does_not_cancel_others(mock_logger
     # All 3 posts should have been attempted despite one failure
     assert call_count == 3, f"Expected 3 POST attempts, got {call_count}"
     # Exactly one error log call for the single failed POST
-    assert mock_logger.error.call_count == 1, (
-        f"Expected 1 error call, got {mock_logger.error.call_count}"
-    )
+    assert mock_logger.error.call_count == 1, f"Expected 1 error call, got {mock_logger.error.call_count}"
     # Assert the single remaining ERROR message format from __process__
     error_call = mock_logger.error.call_args
     assert error_call[0][0] == "Registry POST failed for %s: %s"

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -1,7 +1,7 @@
 import asyncio
 from aprs_backend.clients import RegistryAppConfig, APRSRegistryClient
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 
 from logging import getLogger
 import httpx

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -7,6 +7,32 @@ from logging import getLogger
 import httpx
 
 
+def _fake_async_client(post_fn=None, capture_kwargs=None):
+    """Factory for FakeAsyncClient with an injectable post function and optional kwargs capture."""
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            if capture_kwargs is not None:
+                capture_kwargs.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        if post_fn is not None:
+            post = post_fn
+        else:
+
+            async def post(self, *args, **kwargs):
+                response = MagicMock()
+                response.raise_for_status = MagicMock()
+                return response
+
+    return FakeAsyncClient
+
+
 @pytest.fixture
 def registry_app_config():
     return RegistryAppConfig(
@@ -55,6 +81,10 @@ async def test_APRSRegistryClient_errors(httpx_mock, mock_logger, registry_app_c
     )
     await this_APRSRegistryClient.__process__()
     assert mock_logger.error.call_count == 1
+    # HTTPStatusError includes the response object for diagnostics
+    error_call = mock_logger.error.call_args
+    assert error_call[0][0] == "Registry POST failed for %s: %s, response: %s"
+    assert error_call[0][3] is not None  # response object
 
 
 @pytest.mark.asyncio
@@ -105,21 +135,7 @@ async def test_APRSRegistryClient_timeout_wired_into_client(registry_app_config)
     the AsyncClient call in APRSRegistryClient.__process__.
     """
     captured_kwargs = {}
-
-    class FakeAsyncClient:
-        def __init__(self, **kwargs):
-            captured_kwargs.update(kwargs)
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            pass
-
-        async def post(self, *args, **kwargs):
-            response = MagicMock()
-            response.raise_for_status = MagicMock()
-            return response
+    FakeAsyncClient = _fake_async_client(capture_kwargs=captured_kwargs)
 
     with patch("aprs_backend.clients.aprs_registry.httpx.AsyncClient", FakeAsyncClient):
         client = APRSRegistryClient(
@@ -149,17 +165,7 @@ async def test_APRSRegistryClient_posts_concurrently(registry_app_config):
         response.raise_for_status = MagicMock()
         return response
 
-    class FakeAsyncClient:
-        def __init__(self, **kwargs):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            pass
-
-        post = tracking_post
+    FakeAsyncClient = _fake_async_client(post_fn=tracking_post)
 
     with patch("aprs_backend.clients.aprs_registry.httpx.AsyncClient", FakeAsyncClient):
         # Use a config with multiple callsigns
@@ -195,17 +201,7 @@ async def test_APRSRegistryClient_one_failure_does_not_cancel_others(mock_logger
         response.raise_for_status = MagicMock()
         return response
 
-    class FakeAsyncClient:
-        def __init__(self, **kwargs):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            pass
-
-        post = selective_fail
+    FakeAsyncClient = _fake_async_client(post_fn=selective_fail)
 
     with patch("aprs_backend.clients.aprs_registry.httpx.AsyncClient", FakeAsyncClient):
         multi_config = RegistryAppConfig(
@@ -223,6 +219,6 @@ async def test_APRSRegistryClient_one_failure_does_not_cancel_others(mock_logger
     assert call_count == 3, f"Expected 3 POST attempts, got {call_count}"
     # Exactly one error log call for the single failed POST
     assert mock_logger.error.call_count == 1, f"Expected 1 error call, got {mock_logger.error.call_count}"
-    # Assert the single remaining ERROR message format from __process__
+    # RequestError uses the generic format without response
     error_call = mock_logger.error.call_args
     assert error_call[0][0] == "Registry POST failed for %s: %s"

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -54,7 +54,7 @@ async def test_APRSRegistryClient_errors(httpx_mock, mock_logger, registry_app_c
         app_config=registry_app_config,
     )
     await this_APRSRegistryClient.__process__()
-    assert mock_logger.error.called
+    assert mock_logger.error.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -221,4 +221,10 @@ async def test_APRSRegistryClient_one_failure_does_not_cancel_others(mock_logger
 
     # All 3 posts should have been attempted despite one failure
     assert call_count == 3, f"Expected 3 POST attempts, got {call_count}"
-    assert mock_logger.error.called
+    # Exactly one error log call for the single failed POST
+    assert mock_logger.error.call_count == 1, (
+        f"Expected 1 error call, got {mock_logger.error.call_count}"
+    )
+    # Assert the single remaining ERROR message format from __process__
+    error_call = mock_logger.error.call_args
+    assert error_call[0][0] == "Registry POST failed for %s: %s"

--- a/tests/clients/test_aprs_registry.py
+++ b/tests/clients/test_aprs_registry.py
@@ -1,6 +1,7 @@
+import asyncio
 from aprs_backend.clients import RegistryAppConfig, APRSRegistryClient
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from logging import getLogger
 import httpx
@@ -133,3 +134,91 @@ async def test_APRSRegistryClient_timeout_wired_into_client(registry_app_config)
     assert isinstance(captured_kwargs["timeout"], httpx.Timeout)
     assert captured_kwargs["timeout"].connect == 15.0
     assert captured_kwargs["timeout"].read == 15.0
+
+
+@pytest.mark.asyncio
+async def test_APRSRegistryClient_posts_concurrently(registry_app_config):
+    """Prove that multiple POST requests fire concurrently via asyncio.gather."""
+    call_order = []
+
+    async def tracking_post(*args, **kwargs):
+        call_order.append("start")
+        await asyncio.sleep(0.05)
+        call_order.append("end")
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        return response
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        post = tracking_post
+
+    with patch("aprs_backend.clients.aprs_registry.httpx.AsyncClient", FakeAsyncClient):
+        # Use a config with multiple callsigns
+        multi_config = RegistryAppConfig(
+            description="test",
+            listening_callsigns=["TEST-1", "TEST-2", "TEST-3"],
+        )
+        client = APRSRegistryClient(
+            registry_url="http://test.com",
+            log=getLogger(__name__),
+            app_config=multi_config,
+        )
+        await client.__process__()
+
+    # If posts were sequential, call_order would be: start, end, start, end, start, end
+    # If concurrent, all starts come before all ends: start, start, start, end, end, end
+    assert call_order == ["start", "start", "start", "end", "end", "end"], (
+        f"POSTs were not concurrent. Call order: {call_order}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_APRSRegistryClient_one_failure_does_not_cancel_others(mock_logger, registry_app_config):
+    """Prove that one failing POST does not prevent others from completing."""
+    call_count = 0
+
+    async def selective_fail(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise httpx.RequestError("Simulated failure")
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        return response
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        post = selective_fail
+
+    with patch("aprs_backend.clients.aprs_registry.httpx.AsyncClient", FakeAsyncClient):
+        multi_config = RegistryAppConfig(
+            description="test",
+            listening_callsigns=["TEST-1", "TEST-2", "TEST-3"],
+        )
+        client = APRSRegistryClient(
+            registry_url="http://test.com",
+            log=mock_logger,
+            app_config=multi_config,
+        )
+        await client.__process__()
+
+    # All 3 posts should have been attempted despite one failure
+    assert call_count == 3, f"Expected 3 POST attempts, got {call_count}"
+    assert mock_logger.error.called


### PR DESCRIPTION
## Summary

Delivers parent issue #441: perf(aprs-registry): use asyncio.gather for concurrent POST requests instead of sequential loop

### Child issues integrated

- Closes #526 — Consolidate duplicate registry POST failure logging to a single site

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #441 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`