### PR TITLE
perf(aprs): replace asyncio.sleep(0.001) with sleep(0) for zero-delay cooperative yield

### DIFF
--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -262,7 +262,7 @@ class APRSBackend(ErrBot):
                     log.debug("Message %s needs to be re-sent %s", key, live_packet.json)
                     self.send_message(APRSMessage.from_message_packet(live_packet))
                 # release the loop for a bit
-                await asyncio.sleep(0.001)
+                await asyncio.sleep(0)  # cooperative yield
             # release the loop for a bit longer after we've gone through all keys
             await asyncio.sleep(5)
 
@@ -300,7 +300,7 @@ class APRSBackend(ErrBot):
 
                 self._send_queue.task_done()
             # release the loop for a bit
-            await asyncio.sleep(0.001)
+            await asyncio.sleep(0)  # cooperative yield
 
     async def receive_worker(self) -> bool:
         """_summary_"""
@@ -324,7 +324,7 @@ class APRSBackend(ErrBot):
                 try:
                     parsed_packet = parse(packet_str)
                     # release the loop for a tiny bit
-                    await asyncio.sleep(0.001)
+                    await asyncio.sleep(0)  # cooperative yield
                     if parsed_packet is not None:
                         # filtering should handle this, but belt and syspenders
                         if parsed_packet.to in self.listening_callsigns:

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -376,7 +376,7 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
 
     backend._APRSBackend__drop_message_from_waiting = tracked_drop
 
-    # Patch the per-entry sleep(0.001) so we can drop entry 2 between
+    # Patch the per-entry sleep(0) so we can drop entry 2 between
     # the processing of entry 1 and entry 2 in the snapshot iteration.
     # Use a counter to know which iteration we're on.
     sleep_call_count = 0
@@ -384,7 +384,7 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
 
     async def patched_sleep_with_drop(delay):
         nonlocal sleep_call_count
-        if delay == 0.001:
+        if delay == 0:
             sleep_call_count += 1
             # After the first entry has been processed (first sleep),
             # drop the second entry from _waiting_ack to simulate


### PR DESCRIPTION
## Summary

Delivers parent issue #451: perf(aprs): replace asyncio.sleep(0.001) with sleep(0) for zero-delay cooperative yield


## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #451 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`