### PR TITLE
build(docker): add .dockerignore to exclude .git and tests from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,9 @@ nox
 tests
 .github
 CHANGELOG.md
+*.md
+!README.md
+.pre-commit-config.yaml
+noxfile.py
+.gitignore
+.prettierignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,8 @@ nox
 tests
 .github
 CHANGELOG.md
+# README.md is required at build time: pyproject.toml's "readme" field points to it,
+# and Dockerfile's "uv build" step needs it in the context to populate wheel metadata.
 *.md
 !README.md
 .pre-commit-config.yaml

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,7 @@ tests
 CHANGELOG.md
 # README.md is required at build time: pyproject.toml's "readme" field points to it,
 # and Dockerfile's "uv build" step needs it in the context to populate wheel metadata.
-*.md
+**/*.md
 !README.md
 .pre-commit-config.yaml
 noxfile.py


### PR DESCRIPTION
## Summary

Delivers parent issue #453: build(docker): add .dockerignore to exclude .git and tests from build context

### Child issues integrated

- Closes #537 — Make .dockerignore markdown exclusion recursive to cover nested docs
- Closes #536 — Document the load-bearing !README.md exception in .dockerignore
- Closes #535 — build(docker): extend .dockerignore to exclude docs and dev tooling files

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #453 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`