### PR TITLE
refactor(code-quality): rename modu1e to modul and addresse to address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Wire-format compatibility for ``address`` field (#542)
+
+PRD #454 renamed the Python field from ``addresse`` to ``address`` across the
+Packet class hierarchy.  A compatibility shim was added to preserve the legacy
+``addresse`` JSON key on the wire:
+
+- **Outbound** ``to_json()`` / ``.json`` always emits ``addresse``.
+- **Inbound** ``from_json()`` / ``from_dict()`` accepts both ``addresse`` and
+  ``address``.
+- Applied consistently to ``Packet``, ``AckPacket``, ``RejectPacket``, and
+  ``MessagePacket``.
+- Test coverage added in ``tests/packets/test_serialization.py``.
+
+Contract analysis: the ``.json`` property is used in-repo only as a debug-log
+argument (``aprs_backend/aprs.py``, ``aprs_backend/clients/beacon.py``).  No
+RPC server implementation exists in this repository.  The aprslib parse path
+in ``parser.py`` already hand-translates ``addresse`` to ``address``.  The shim
+ensures any external or persisted JSON consumers of the ``addresse`` key
+continue to work.
+
 ## [0.5.1](https://github.com/andrewthetechie/err-aprs-backend/compare/v0.5.0...v0.5.1) (2024-05-17)
 
 

--- a/aprs_backend/aprs.py
+++ b/aprs_backend/aprs.py
@@ -430,7 +430,7 @@ class APRSBackend(ErrBot):
         msg_packet = MessagePacket(
             from_call=msg.frm.callsign,
             to_call=msg.to.callsign,
-            addresse=msg.to.callsign,
+            address=msg.to.callsign,
             message_text=msg_text,
             msgNo=msgNo,
             last_send_attempt=last_send_attempt,
@@ -478,7 +478,7 @@ class APRSBackend(ErrBot):
             "Processing ACK/REJ packet for msgno %s from %s to %s",
             packet.msgNo,
             packet.from_call,
-            packet.addresse,
+            packet.address,
         )
         await self.__drop_message_from_waiting(f"{packet.from_call}-{packet.msgNo}")
 
@@ -500,7 +500,7 @@ class APRSBackend(ErrBot):
         log.debug(packet.raw_dict)
         # send an ack to this message
         await self._ack_message(packet)
-        this_packet_hash = hash_packet(packet.to, packet.addresse, packet.msgNo)
+        this_packet_hash = hash_packet(packet.to, packet.address, packet.msgNo)
         async with self._packet_cache_lock:
             if self._packet_cache.get(this_packet_hash, None) is not None:
                 log.info("Duplicate packet %s. Skipping processing", packet.json)
@@ -515,7 +515,7 @@ class APRSBackend(ErrBot):
         this_ack = AckPacket(
             from_call=packet.to,
             to_call=packet.from_call,
-            addresse=packet.from_call,
+            address=packet.from_call,
             msgNo=packet.msgNo,
         )
         await this_ack.prepare(self._message_counter)

--- a/aprs_backend/message.py
+++ b/aprs_backend/message.py
@@ -21,5 +21,5 @@ class APRSMessage(Message):
             },
         )
         this_msg.frm = APRSPerson(callsign=packet.from_call)
-        this_msg.to = APRSPerson(callsign=packet.addresse)
+        this_msg.to = APRSPerson(callsign=packet.address)
         return this_msg

--- a/aprs_backend/packets/__init__.py
+++ b/aprs_backend/packets/__init__.py
@@ -14,7 +14,7 @@ class Packet:
     _type: str = field(default="Packet", hash=False)
     from_call: str | None = field(default=None)
     to_call: str | None = field(default=None)
-    addresse: str | None = field(default=None)
+    address: str | None = field(default=None)
     format: str | None = field(default=None)
     msgNo: str | None = field(default=None)  # noqa: N815
     packet_type: str | None = field(default=None)
@@ -35,7 +35,7 @@ class Packet:
 
     @property
     def to(self):
-        return self.addresse if self.addresse is not None else self.to_call
+        return self.address if self.address is not None else self.to_call
 
     @property
     def json(self):
@@ -55,7 +55,7 @@ class Packet:
     @property
     def key(self) -> str:
         """Build a key for finding this packet in a dict."""
-        return f"{self.from_call}:{self.addresse}:{self.msgNo}"
+        return f"{self.from_call}:{self.address}:{self.msgNo}"
 
     def update_timestamp(self) -> None:
         self.timestamp = init_timestamp()

--- a/aprs_backend/packets/__init__.py
+++ b/aprs_backend/packets/__init__.py
@@ -1,13 +1,53 @@
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
+from dataclasses_json.core import _ExtendedEncoder
 from aprs_backend.utils.counter import MessageCounter
 from aprs_backend.utils.position import latitude_to_ddm, longitude_to_ddm
 from aprs_backend.utils.datetime import init_timestamp
 from datetime import datetime, timezone
 from better_profanity import profanity
 from aprs_backend.version import __version__ as BACKEND_VERSION
+import json as _json
 
 
+def _patch_addresse_compat(cls):
+    """Patch a dataclass_json class to emit/accept the legacy ``addresse`` wire key.
+
+    The Python field is ``address`` (renamed in PRD #454) but the serialized
+    JSON key remains ``addresse`` for backwards compatibility with any
+    external or persisted consumers.  This must be applied after
+    ``@dataclass_json`` so that the decorator-generated methods are
+    overridden.
+    """
+    _orig_from_dict = cls.from_dict
+
+    def _to_json(self, *args, **kwargs):  # noqa: ARG002
+        d = self.to_dict()
+        if "address" in d:
+            d["addresse"] = d.pop("address")
+        return _json.dumps(d, cls=_ExtendedEncoder)
+
+    @classmethod
+    def _from_json(cls_inner, s, *args, **kwargs):  # noqa: ARG002
+        d = _json.loads(s)
+        if "addresse" in d:
+            d["address"] = d.pop("addresse")
+        return cls_inner.from_dict(d)
+
+    @classmethod
+    def _from_dict(cls_inner, kvs, *args, **kwargs):  # noqa: ARG002
+        d = dict(kvs)
+        if "addresse" in d:
+            d["address"] = d.pop("addresse")
+        return _orig_from_dict.__func__(cls_inner, d)
+
+    cls.to_json = _to_json
+    cls.from_json = _from_json
+    cls.from_dict = _from_dict
+    return cls
+
+
+@_patch_addresse_compat
 @dataclass_json
 @dataclass(unsafe_hash=True)
 class Packet:
@@ -115,6 +155,7 @@ class Packet:
         return repr
 
 
+@_patch_addresse_compat
 @dataclass_json
 @dataclass(unsafe_hash=True)
 class AckPacket(Packet):
@@ -124,6 +165,7 @@ class AckPacket(Packet):
         self.payload = f":{self.to_call: <9}:ack{self.msgNo}"
 
 
+@_patch_addresse_compat
 @dataclass_json
 @dataclass(unsafe_hash=True)
 class RejectPacket(Packet):
@@ -134,6 +176,7 @@ class RejectPacket(Packet):
         self.payload = f":{self.to_call: <9}:rej{self.msgNo}"
 
 
+@_patch_addresse_compat
 @dataclass_json
 @dataclass(unsafe_hash=True)
 class MessagePacket(Packet):

--- a/aprs_backend/packets/parser.py
+++ b/aprs_backend/packets/parser.py
@@ -80,21 +80,24 @@ def parse(packet_str: str) -> AckPacket | RejectPacket | MessagePacket | None:
     raw_aprs_packet["is_new_ackrej"] = is_new_ackrej
     raw_aprs_packet["packet_type"] = get_packet_type(raw_aprs_packet)
 
+    # Normalize aprslib's legacy "addresse" key to "address" once, before
+    # dispatching to per-type branches.  Only clobber if "address" is not
+    # already present, preserving existing fallback semantics.
+    if "addresse" in raw_aprs_packet and "address" not in raw_aprs_packet:
+        raw_aprs_packet["address"] = raw_aprs_packet.pop("addresse")
+
     match raw_aprs_packet["packet_type"]:
         case "MESSAGE":
             packet = MessagePacket.from_dict(raw_aprs_packet)
             packet.from_call = from_callsign
-            packet.address = raw_aprs_packet.get("addresse", packet.address)
 
         case "ACK":
             packet = AckPacket.from_dict(raw_aprs_packet)
             packet.from_call = from_callsign
-            packet.address = raw_aprs_packet.get("addresse", packet.address)
 
         case "REJECT":
             packet = RejectPacket.from_dict(raw_aprs_packet)
             packet.from_call = from_callsign
-            packet.address = raw_aprs_packet.get("addresse", packet.address)
 
         case _:
             log.info("Packet is not a message, ack, or reject. Not parsing it")

--- a/aprs_backend/packets/parser.py
+++ b/aprs_backend/packets/parser.py
@@ -253,7 +253,7 @@ def get_packet_type(packet: dict) -> str:
 
 
 @lru_cache(maxsize=256)
-def hash_packet(to: str | None, addresse: str | None, msg_no: str | None) -> str:
+def hash_packet(to: str | None, address: str | None, msg_no: str | None) -> str:
     """Return a deterministic SHA-256 hash for packet deduplication.
 
     Any ``None`` argument is normalized to the empty string before hashing.
@@ -263,7 +263,7 @@ def hash_packet(to: str | None, addresse: str | None, msg_no: str | None) -> str
     ``"-None"`` hash.
     """
     safe_to = to if to is not None else ""
-    safe_addresse = addresse if addresse is not None else ""
+    safe_address = address if address is not None else ""
     safe_msg_no = msg_no if msg_no is not None else ""
-    stations = tuple(sorted((safe_to, safe_addresse)))
+    stations = tuple(sorted((safe_to, safe_address)))
     return sha256((",".join(stations) + f"-{safe_msg_no}").encode()).hexdigest()

--- a/aprs_backend/packets/parser.py
+++ b/aprs_backend/packets/parser.py
@@ -84,14 +84,17 @@ def parse(packet_str: str) -> AckPacket | RejectPacket | MessagePacket | None:
         case "MESSAGE":
             packet = MessagePacket.from_dict(raw_aprs_packet)
             packet.from_call = from_callsign
+            packet.address = raw_aprs_packet.get("addresse", packet.address)
 
         case "ACK":
             packet = AckPacket.from_dict(raw_aprs_packet)
             packet.from_call = from_callsign
+            packet.address = raw_aprs_packet.get("addresse", packet.address)
 
         case "REJECT":
             packet = RejectPacket.from_dict(raw_aprs_packet)
             packet.from_call = from_callsign
+            packet.address = raw_aprs_packet.get("addresse", packet.address)
 
         case _:
             log.info("Packet is not a message, ack, or reject. Not parsing it")

--- a/aprs_backend/utils/plugins.py
+++ b/aprs_backend/utils/plugins.py
@@ -108,15 +108,15 @@ class APRSPluginInfo:
         # load the module
         module_name = base_module_name + "." + self.module
         spec = spec_from_file_location(module_name, self.location.parent / (self.module + ".py"))
-        modu1e = module_from_spec(spec)
-        spec.loader.exec_module(modu1e)
-        sys.modules[module_name] = modu1e
+        modul = module_from_spec(spec)
+        spec.loader.exec_module(modul)
+        sys.modules[module_name] = modul
 
         # introspect the modules to find plugin classes
         def is_plugin(member):
             return inspect.isclass(member) and issubclass(member, baseclass) and member != baseclass
 
-        plugin_classes = inspect.getmembers(modu1e, is_plugin)
+        plugin_classes = inspect.getmembers(modul, is_plugin)
         return plugin_classes
 
 

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aprs_backend.packets import MessagePacket
-from aprs_backend.packets.parser import hash_packet
+from aprs_backend.packets import AckPacket, MessagePacket, RejectPacket
+from aprs_backend.packets.parser import hash_packet, parse
 
 
 def _build_minimal_backend():
@@ -190,3 +190,31 @@ async def test_dedup_hash_and_cache_isolation():
     async with backend._packet_cache_lock:
         assert backend._packet_cache.get(distinct_hash, None) is None
         backend._packet_cache[distinct_hash] = packet_distinct
+
+
+def test_parse_message_populates_address():
+    """Regression test: parse() maps aprslib's 'addresse' key onto packet.address
+    for MESSAGE packets. If this fixup is removed, address would be None."""
+    # 9-character addresse field required by aprslib (EMAIL-2 + 2 spaces)
+    packet = parse("DF1JSL-4>APL1,qAC,WIDE1-1::EMAIL-2  :Hello{12345")
+    assert packet is not None
+    assert isinstance(packet, MessagePacket)
+    assert packet.address == "EMAIL-2"
+
+
+def test_parse_ack_populates_address():
+    """Regression test: parse() maps aprslib's 'addresse' key onto packet.address
+    for ACK packets."""
+    packet = parse("DF1JSL-4>APL1,qAC,WIDE1-1::EMAIL-2  :ack12345")
+    assert packet is not None
+    assert isinstance(packet, AckPacket)
+    assert packet.address == "EMAIL-2"
+
+
+def test_parse_reject_populates_address():
+    """Regression test: parse() maps aprslib's 'addresse' key onto packet.address
+    for REJECT packets."""
+    packet = parse("DF1JSL-4>APL1,qAC,WIDE1-1::EMAIL-2  :rej12345")
+    assert packet is not None
+    assert isinstance(packet, RejectPacket)
+    assert packet.address == "EMAIL-2"

--- a/tests/packets/test_parser.py
+++ b/tests/packets/test_parser.py
@@ -22,7 +22,7 @@ def _build_minimal_backend():
 
 
 def test_hash_is_deterministic():
-    """Same (to, addresse, msg_no) always produces the same hash."""
+    """Same (to, address, msg_no) always produces the same hash."""
     h1 = hash_packet("W1AW", "W2AW", "001")
     h2 = hash_packet("W1AW", "W2AW", "001")
     assert h1 == h2
@@ -30,7 +30,7 @@ def test_hash_is_deterministic():
 
 
 def test_hash_normalizes_station_order():
-    """Swapped to/addresse arguments produce the same hash (alphabetically sorted)."""
+    """Swapped to/address arguments produce the same hash (alphabetically sorted)."""
     h1 = hash_packet("W2AW", "W1AW", "001")
     h2 = hash_packet("W1AW", "W2AW", "001")
     assert h1 == h2
@@ -60,8 +60,8 @@ def test_hash_handles_none_to():
     assert len(h) == 64
 
 
-def test_hash_handles_none_addresse():
-    """None for 'addresse' is normalized to empty string (no TypeError)."""
+def test_hash_handles_none_address():
+    """None for 'address' is normalized to empty string (no TypeError)."""
     h = hash_packet("W1AW", None, "001")
     assert isinstance(h, str)
     assert len(h) == 64
@@ -93,20 +93,20 @@ def test_hash_none_inputs_are_distinct_from_non_none():
 
 @pytest.mark.asyncio
 async def test_process_message_dedup_skips_repeated_packet():
-    """The dedup path in _process_message skips a repeated packet (same to/addresse/msgNo)."""
+    """The dedup path in _process_message skips a repeated packet (same to/address/msgNo)."""
 
-    # Build two MessagePackets with identical (to, addresse, msgNo)
+    # Build two MessagePackets with identical (to, address, msgNo)
     packet1 = MessagePacket(
         from_call="W1AW",
         to_call="W2AW",
-        addresse="W2AW",
+        address="W2AW",
         msgNo="001",
         message_text="hello",
     )
     packet2 = MessagePacket(
         from_call="W1AW",
         to_call="W2AW",
-        addresse="W2AW",
+        address="W2AW",
         msgNo="001",
         message_text="hello again",
     )
@@ -114,14 +114,14 @@ async def test_process_message_dedup_skips_repeated_packet():
     packet3 = MessagePacket(
         from_call="W1AW",
         to_call="W2AW",
-        addresse="W2AW",
+        address="W2AW",
         msgNo="002",
         message_text="different message",
     )
 
     # Verify both packets produce the same hash
-    h1 = hash_packet(packet1.to, packet1.addresse, packet1.msgNo)
-    h2 = hash_packet(packet2.to, packet2.addresse, packet2.msgNo)
+    h1 = hash_packet(packet1.to, packet1.address, packet1.msgNo)
+    h2 = hash_packet(packet2.to, packet2.address, packet2.msgNo)
     assert h1 == h2
 
     backend = _build_minimal_backend()
@@ -159,7 +159,7 @@ async def test_dedup_hash_and_cache_isolation():
     packet_dup = MessagePacket(
         from_call="W1AW",
         to_call="W2AW",
-        addresse="W2AW",
+        address="W2AW",
         msgNo="001",
         message_text="dup",
     )
@@ -167,13 +167,13 @@ async def test_dedup_hash_and_cache_isolation():
     packet_distinct = MessagePacket(
         from_call="W1AW",
         to_call="W2AW",
-        addresse="W2AW",
+        address="W2AW",
         msgNo="002",
         message_text="distinct",
     )
 
-    dup_hash = hash_packet(packet_dup.to, packet_dup.addresse, packet_dup.msgNo)
-    distinct_hash = hash_packet(packet_distinct.to, packet_distinct.addresse, packet_distinct.msgNo)
+    dup_hash = hash_packet(packet_dup.to, packet_dup.address, packet_dup.msgNo)
+    distinct_hash = hash_packet(packet_distinct.to, packet_distinct.address, packet_distinct.msgNo)
     assert dup_hash != distinct_hash
 
     # Simulate the dedup logic from _process_message lines 458-463:

--- a/tests/packets/test_serialization.py
+++ b/tests/packets/test_serialization.py
@@ -1,0 +1,204 @@
+"""Wire-format compatibility tests for the ``address`` / ``addresse`` field rename.
+
+PRD #454 renamed the Python field from ``addresse`` to ``address`` across the
+Packet class hierarchy.  These tests pin the serialized JSON shape so that
+future changes cannot silently break the wire-format contract.
+
+The ``.json`` property is referenced in-repo only as a debug-log argument
+(aprs_backend/aprs.py, aprs_backend/clients/beacon.py).  No RPC server
+implementation exists in this repository.  ``from_dict`` is called only on the
+aprslib parse path in parser.py, where the legacy ``addresse`` key is already
+hand-translated to ``address``.
+
+The compatibility shim ensures:
+- Outbound JSON always emits ``addresse`` (legacy wire key).
+- Inbound JSON/dict accepts both ``addresse`` and ``address``.
+"""
+
+import json
+
+import pytest
+
+from aprs_backend.packets import AckPacket, MessagePacket, Packet, RejectPacket
+
+
+@pytest.mark.parametrize(
+    "packet_cls,factory_kwargs",
+    [
+        (Packet, {"from_call": "W1AW", "to_call": "W2AW", "address": "TEST"}),
+        (
+            AckPacket,
+            {"from_call": "W1AW", "to_call": "W2AW", "address": "TEST", "msgNo": "001"},
+        ),
+        (
+            RejectPacket,
+            {"from_call": "W1AW", "to_call": "W2AW", "address": "TEST", "msgNo": "001"},
+        ),
+        (
+            MessagePacket,
+            {
+                "from_call": "W1AW",
+                "to_call": "W2AW",
+                "address": "TEST",
+                "msgNo": "001",
+                "message_text": "hello",
+            },
+        ),
+    ],
+)
+def test_to_json_emits_legacy_addresse_key(packet_cls, factory_kwargs):
+    """Outbound to_json() must emit ``addresse`` (not ``address``)."""
+    packet = packet_cls(**factory_kwargs)
+    data = json.loads(packet.to_json())
+    assert "addresse" in data, f"Expected 'addresse' key in {packet_cls.__name__} JSON"
+    assert data["addresse"] == "TEST"
+    assert "address" not in data, f"'address' key must not appear in {packet_cls.__name__} JSON"
+
+
+@pytest.mark.parametrize(
+    "packet_cls,factory_kwargs",
+    [
+        (Packet, {"from_call": "W1AW", "to_call": "W2AW", "address": "TEST"}),
+        (
+            AckPacket,
+            {"from_call": "W1AW", "to_call": "W2AW", "address": "TEST", "msgNo": "001"},
+        ),
+        (
+            RejectPacket,
+            {"from_call": "W1AW", "to_call": "W2AW", "address": "TEST", "msgNo": "001"},
+        ),
+        (
+            MessagePacket,
+            {
+                "from_call": "W1AW",
+                "to_call": "W2AW",
+                "address": "TEST",
+                "msgNo": "001",
+                "message_text": "hello",
+            },
+        ),
+    ],
+)
+def test_json_property_emits_legacy_addresse_key(packet_cls, factory_kwargs):
+    """The .json property (used by debug logging) must emit ``addresse``."""
+    packet = packet_cls(**factory_kwargs)
+    data = json.loads(packet.json)
+    assert "addresse" in data
+    assert data["addresse"] == "TEST"
+
+
+@pytest.mark.parametrize(
+    "packet_cls,legacy_json",
+    [
+        (Packet, '{"addresse": "LEGACY", "from_call": "W1AW"}'),
+        (
+            AckPacket,
+            '{"addresse": "LEGACY", "from_call": "W1AW", "msgNo": "001"}',
+        ),
+        (
+            RejectPacket,
+            '{"addresse": "LEGACY", "from_call": "W1AW", "msgNo": "001"}',
+        ),
+        (
+            MessagePacket,
+            '{"addresse": "LEGACY", "from_call": "W1AW", "msgNo": "001", "message_text": "hi"}',
+        ),
+    ],
+)
+def test_from_json_accepts_legacy_addresse_key(packet_cls, legacy_json):
+    """Inbound from_json() must accept the legacy ``addresse`` key."""
+    packet = packet_cls.from_json(legacy_json)
+    assert packet.address == "LEGACY"
+
+
+@pytest.mark.parametrize(
+    "packet_cls,current_json",
+    [
+        (Packet, '{"address": "CURRENT", "from_call": "W1AW"}'),
+        (
+            AckPacket,
+            '{"address": "CURRENT", "from_call": "W1AW", "msgNo": "001"}',
+        ),
+        (
+            RejectPacket,
+            '{"address": "CURRENT", "from_call": "W1AW", "msgNo": "001"}',
+        ),
+        (
+            MessagePacket,
+            '{"address": "CURRENT", "from_call": "W1AW", "msgNo": "001", "message_text": "hi"}',
+        ),
+    ],
+)
+def test_from_json_accepts_current_address_key(packet_cls, current_json):
+    """Inbound from_json() must also accept the current ``address`` key."""
+    packet = packet_cls.from_json(current_json)
+    assert packet.address == "CURRENT"
+
+
+@pytest.mark.parametrize(
+    "packet_cls,legacy_dict",
+    [
+        (Packet, {"addresse": "LEGACY", "from_call": "W1AW"}),
+        (AckPacket, {"addresse": "LEGACY", "from_call": "W1AW", "msgNo": "001"}),
+        (RejectPacket, {"addresse": "LEGACY", "from_call": "W1AW", "msgNo": "001"}),
+        (
+            MessagePacket,
+            {"addresse": "LEGACY", "from_call": "W1AW", "msgNo": "001", "message_text": "hi"},
+        ),
+    ],
+)
+def test_from_dict_accepts_legacy_addresse_key(packet_cls, legacy_dict):
+    """Inbound from_dict() must accept the legacy ``addresse`` key."""
+    packet = packet_cls.from_dict(legacy_dict)
+    assert packet.address == "LEGACY"
+
+
+@pytest.mark.parametrize(
+    "packet_cls,current_dict",
+    [
+        (Packet, {"address": "CURRENT", "from_call": "W1AW"}),
+        (AckPacket, {"address": "CURRENT", "from_call": "W1AW", "msgNo": "001"}),
+        (RejectPacket, {"address": "CURRENT", "from_call": "W1AW", "msgNo": "001"}),
+        (
+            MessagePacket,
+            {"address": "CURRENT", "from_call": "W1AW", "msgNo": "001", "message_text": "hi"},
+        ),
+    ],
+)
+def test_from_dict_accepts_current_address_key(packet_cls, current_dict):
+    """Inbound from_dict() must also accept the current ``address`` key."""
+    packet = packet_cls.from_dict(current_dict)
+    assert packet.address == "CURRENT"
+
+
+@pytest.mark.parametrize(
+    "packet_cls,factory_kwargs",
+    [
+        (Packet, {"from_call": "W1AW", "to_call": "W2AW", "address": "W2AW"}),
+        (
+            AckPacket,
+            {"from_call": "W1AW", "to_call": "W2AW", "address": "W2AW", "msgNo": "001"},
+        ),
+        (
+            RejectPacket,
+            {"from_call": "W1AW", "to_call": "W2AW", "address": "W2AW", "msgNo": "001"},
+        ),
+        (
+            MessagePacket,
+            {
+                "from_call": "W1AW",
+                "to_call": "W2AW",
+                "address": "W2AW",
+                "msgNo": "001",
+                "message_text": "hello",
+            },
+        ),
+    ],
+)
+def test_roundtrip_preserves_address(packet_cls, factory_kwargs):
+    """Serializing then deserializing must preserve the address field."""
+    original = packet_cls(**factory_kwargs)
+    serialized = original.to_json()
+    restored = packet_cls.from_json(serialized)
+    assert restored.address == original.address
+    assert restored.from_call == original.from_call

--- a/tests/test_aprs.py
+++ b/tests/test_aprs.py
@@ -70,7 +70,7 @@ def _make_packet(msgno: int = 1, last_send_attempt: int = 0, last_send_time: dat
     pkt = MessagePacket(
         from_call="TEST-1",
         to_call="REMOTE-1",
-        addresse="REMOTE-1",
+        address="REMOTE-1",
         message_text="hello",
         msgNo=str(msgno),
         last_send_attempt=last_send_attempt,
@@ -408,7 +408,7 @@ async def test_retry_worker_skips_ack_entry_removed_mid_cycle(backend):
             pass
 
     # Entry 2 was removed mid-cycle, so it must NOT have been resent.
-    sent_keys = [p.addresse + "-" + p.msgNo for p in sent_packets if p is not None]
+    sent_keys = [p.address + "-" + p.msgNo for p in sent_packets if p is not None]
     assert "REMOTE-1-2" not in sent_keys, "send_message must NOT be called for an entry ACKed mid-cycle"
 
     # No error-level log should be emitted for the expected concurrent removal


### PR DESCRIPTION
## Summary

Delivers parent issue #454: refactor(code-quality): rename modu1e to modul and addresse to address

### Child issues integrated

- Closes #543 — Centralize duplicated aprslib `addresse`->`address` fix-up across parse() branches
- Closes #542 — Add wire-format compatibility for renamed `address` field (Packet dataclass_json contract)
- Closes #539 — Rename addresse field to address across Packet hierarchy and references
- Closes #538 — Rename modu1e to modul in plugins.py

## Test plan

- [ ] CI passes
- [ ] Acceptance criteria in #454 satisfied

🤖 Assembled by `deliver-stuck-parent.mts`